### PR TITLE
Handle missing values after joining datasets

### DIFF
--- a/src/witan/models/dem/ccm/fert/hist_asfr_age.clj
+++ b/src/witan/models/dem/ccm/fert/hist_asfr_age.clj
@@ -42,17 +42,24 @@
   [{:keys [at-risk-this-year at-risk-last-year]}]
   (let [ds-joined (i/$join [[:gss.code :sex :age] [:gss.code :sex :age]]
                            at-risk-last-year
-                           at-risk-this-year)]
-    {:births-pool ds-joined}
-    ;; FIXME: cannot perform calculation due to missing values (NAs in R)
-    ;; (-> ds-joined
-    ;;     (ds/add-column :birth-pool (i/$map (fn [this-yr last-yr]
-    ;;                                          (double (/ (+ this-yr last-yr) 2)))
-    ;;                                        [:popn-this-yr :popn-last-yr] ds-joined))
-    ;;     (ds/remove-columns [:popn-this-yr :popn-last-yr]))
-    ;; TODO: Make sure any missing values in :birth-pool column are set to zero
-    ;; TODO: Remove unwanted columns
-    ))
+                           at-risk-this-year)
+        ;; Replace `nil` by `NaN` in popn-last-yr column
+        ds-joined-cleaned (ds/replace-column ds-joined :popn-last-yr
+                                             (i/$map (fn [lst-yr-popn]
+                                                       (if (nil? lst-yr-popn) (Double/NaN)
+                                                           lst-yr-popn)) :popn-last-yr ds-joined))
+        ds-bp-nan (-> ds-joined-cleaned
+                      ;; Add a birth-pool column that averages popn-this-yr and popn-last-yr
+                      (ds/add-column :birth-pool (i/$map (fn [this-yr last-yr]
+                                                           (double (/ (+ this-yr last-yr) 2)))
+                                                         [:popn-this-yr :popn-last-yr]
+                                                         ds-joined-cleaned))
+                      (ds/remove-columns [:popn-this-yr :popn-last-yr]))]
+    (hash-map :births-pool ;; Replace `NaN` by 0.0 in the birth-pool column
+              (ds/replace-column ds-bp-nan :birth-pool
+                                 (i/$map (fn [bp]
+                                           (if (Double/isNaN bp) 0.0 bp))
+                                         :birth-pool ds-bp-nan)))))
 
 (defn ->historic-fertility
   "Calculates historic fertility rates using births by age of mother data

--- a/src/witan/models/dem/ccm/fert/hist_asfr_age.clj
+++ b/src/witan/models/dem/ccm/fert/hist_asfr_age.clj
@@ -45,9 +45,9 @@
                            at-risk-this-year)]
     (hash-map :births-pool
               (-> ds-joined
-                  (ds/add-column :birth-pool (i/$map (fn [this-yr last-yr]
-                                                       (if (nil? last-yr) 0.0
-                                                           (double (/ (+ this-yr last-yr) 2))))
+                  (ds/add-column :birth-pool (i/$map (fnil (fn [this-yr last-yr]
+                                                             (double (/ (+ this-yr last-yr) 2)))
+                                                           0 0)
                                                      [:popn-this-yr :popn-last-yr] ds-joined))
                   (ds/remove-columns [:popn-this-yr :popn-last-yr])))))
 

--- a/test/witan/models/dem/ccm/fert/hist_asfr_age_test.clj
+++ b/test/witan/models/dem/ccm/fert/hist_asfr_age_test.clj
@@ -127,3 +127,12 @@
     (is (same-coll? [:gss.code :sex :age :year :popn-last-yr]
                     (ds/column-names (:at-risk-last-year
                                       (->at-risk-last-year from-births-data-year)))))))
+
+(deftest ->births-pool-test
+  (testing "The data transformation returns the correct columns"
+    (is (same-coll? [:age :sex :gss.code :year :birth-pool]
+                    (ds/column-names (:births-pool (->births-pool for-births-pool))))))
+  (testing "No nil or NaN in the birth-pool column"
+    (is (not-any? nil? (i/$ :birth-pool (:births-pool (->births-pool for-births-pool)))))
+    (is (not-any? #(Double/isNaN %)
+                  (i/$ :birth-pool (:births-pool (->births-pool for-births-pool)))))))


### PR DESCRIPTION
- 1st try: Use `java.Double.NaN` to replace `nil` in "popn-last-yr", do the calculation, then replace `NaN` by `0.0`. <- This stays very close to the R code.
- 2nd try: Directly use either 0.0 or the calculation results. No need for `NaN`.
