### PR TITLE
Rename data input keys

### DIFF
--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -19,7 +19,7 @@
 (defworkflowfn ->starting-popn
   "Takes in a dataset of popn estimates and a year for the projection.
    Returns a dataset w/ the starting popn (popn for the previous year)."
-  {:witan/name :get-starting-popn
+  {:witan/name :ccm-core/get-starting-popn
    :witan/version "1.0"
    :witan/input-schema {:popn PopnSchema}
    :witan/param-schema {:first-proj-year s/Int}
@@ -36,7 +36,7 @@
   "Takes in a dataset of popn estimates, a first year
    and last year. Implement the looping to output the projections
    for the range of years between the first and last year."
-  {:witan/name :exec-core-ccm
+  {:witan/name :ccm-core/exec-core-ccm
    :witan/version "1.0"
    :witan/input-schema {:popn PopnSchema}
    :witan/param-schema {:first-proj-year s/Int

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -11,11 +11,7 @@
    :columns (mapv #(s/one [(second %)] (format "col %s" (name (first %)))) col-vec)
    s/Keyword s/Any})
 
-(def HistoricPopnEstimates
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:popn s/Int]]))
-
-(def StartingPopn
+(def PopnSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:popn s/Int]]))
 
@@ -25,23 +21,27 @@
    Returns a dataset w/ the starting popn (popn for the previous year)."
   {:witan/name :get-starting-popn
    :witan/version "1.0"
-   :witan/input-schema {:historic-popn-estimates HistoricPopnEstimates}
-   :witan/param-schema {:year s/Int}
-   :witan/output-schema {:starting-popn StartingPopn}}
-  [{:keys [historic-popn-estimates]} {:keys [year]}]
-  {:starting-popn (i/query-dataset historic-popn-estimates {:year (dec year)})})
+   :witan/input-schema {:popn PopnSchema}
+   :witan/param-schema {:first-proj-year s/Int}
+   :witan/output-schema {:starting-popn PopnSchema}}
+  [{:keys [popn]} {:keys [first-proj-year]}]
+  (let [latest-yr (reduce max (i/$ :year popn))]
+    (if (>= latest-yr first-proj-year)
+      {:starting-popn (i/query-dataset popn {:year (dec latest-yr)})}
+      (throw (Exception.
+              (format "The latest year in the base popn (%d) is expected to be greater than %d"
+                      latest-yr first-proj-year))))))
 
-(defworkflowfn core-loop
+(defworkflowfn ccm-core
   "Takes in a dataset of popn estimates, a first year
    and last year. Implement the looping to output the projections
    for the range of years between the first and last year."
-  {:witan/name :exec-core-loop
+  {:witan/name :exec-core-ccm
    :witan/version "1.0"
-   :witan/input-schema {:historic-popn-estimates HistoricPopnEstimates}
+   :witan/input-schema {:popn PopnSchema}
    :witan/param-schema {:first-proj-year s/Int
                         :last-proj-year s/Int}
-   :witan/output-schema {:starting-popn StartingPopn} ;; TO BE UPDATED
+   :witan/output-schema {:starting-popn PopnSchema} ;; TO BE UPDATED
    :witan/exported? true}
   [inputs params]
-  (let [new-params (rename-keys params {:first-proj-year :year})]
-    (->starting-popn inputs new-params)))
+  (->starting-popn inputs params))

--- a/src/witan/models/load_data.clj
+++ b/src/witan/models/load_data.clj
@@ -4,7 +4,10 @@
             [clojure-csv.core :as csv]
             [schema.coerce :as coerce]
             [schema.core :as s]
-            [clojure.core.matrix.dataset :as ds]))
+            [clojure.core.matrix.dataset :as ds]
+            [witan.models.dem.ccm.core.projection-loop :refer [PopnSchema]]
+            [witan.models.dem.ccm.fert.hist-asfr-age :refer [BirthsDataSchema
+                                                             AtRiskPopnSchema ]]))
 
 (defn- custom-keyword [coll]
   (mapv #(-> %
@@ -33,21 +36,9 @@
    :columns (mapv #(s/one [(second %)] (format "col %s" (name (first %)))) col-vec)
    s/Keyword s/Any})
 
-(def BirthsDataSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:births s/Num] [:year s/Int]]))
-
-(def AtRiskPopnSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:year s/Int]
-                           [:popn s/Num] [:actualyear s/Int] [:actualage s/Int]]))
-
 (def HistBirthsEst
   (make-ordered-ds-schema [[:gss-code s/Str] [:district s/Str] [:sex s/Str] [:age s/Int]
                            [:var s/Str] [:year s/Int] [:estimate s/Num]]))
-
-(def HistPopnEst
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:popn s/Int]]))
 
 (defn make-row-schema
   [col-schema]
@@ -105,10 +96,10 @@
   {:column-names (apply-col-names-schema HistBirthsEst csv-data)
    :columns (vec (apply-row-schema HistBirthsEst csv-data))})
 
-(defmethod apply-rec-coercion :historic-popn-estimates
+(defmethod apply-rec-coercion :popn
   [data-info csv-data]
-  {:column-names (apply-col-names-schema HistPopnEst csv-data)
-   :columns (vec (apply-row-schema HistPopnEst csv-data))})
+  {:column-names (apply-col-names-schema PopnSchema csv-data)
+   :columns (vec (apply-row-schema PopnSchema csv-data))})
 
 (defn dataset-after-coercion
   [{:keys [column-names columns]}]

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -10,14 +10,11 @@
 ;; Load testing data
 ;; NEED TO GET THE RIGHT INPUT -> mye.est
 (def data-inputs (ld/load-datasets
-                  {:historic-popn-estimates
+                  {:popn
                    "resources/test_data/bristol_hist_popn_est.csv"}))
 
 (def params {:first-proj-year 2014
-             :last-proj-year 2040})
-
-(def params-2 {:year 2014
-               :last-proj-year 2040})
+             :last-proj-year 2041})
 
 ;; Useful fn:
 (defn- same-coll? [coll1 coll2]
@@ -26,14 +23,14 @@
 ;; Tests:
 (deftest ->starting-popn-test
   (testing "The starting popn is returned"
-    (let [get-start-popn (->starting-popn data-inputs params-2)]
-      (is (same-coll? [:starting-popn :historic-popn-estimates] (keys get-start-popn)))
+    (let [get-start-popn (->starting-popn data-inputs params)]
+      (is (same-coll? [:starting-popn :popn] (keys get-start-popn)))
       (is (same-coll? [:gss-code :sex :age :year :popn]
                       (ds/column-names (:starting-popn get-start-popn))))
       (is (same-coll? [2013] (set (i/$ :year (:starting-popn
-                                              (->starting-popn data-inputs params-2)))))))))
+                                              (->starting-popn data-inputs params)))))))))
 
-(deftest core-loop-test
+(deftest ccm-core-test
   (testing "The intermediary outputs are added to the global map"
-    (let [exec-loop (core-loop data-inputs params)]
-      (is (contains? exec-loop :starting-popn)))))
+    (let [exec-core (ccm-core data-inputs params)]
+      (is (contains? exec-core :starting-popn)))))


### PR DESCRIPTION
- Name the population entering the core component `:base-popn`.
- Update the schema name.
- Remove the step to add a `:year` to the data input map.

=> more changes to be addressed on the next branch
