### PR TITLE
Implement changes to simplify the code in preparation for the loop.

### DIFF
--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -22,6 +22,17 @@
   [popn]
   (reduce max (i/$ :year popn)))
 
+(defworkflowfn keep-looping?
+  {:witan/name :ccm-core/ccm-loop-pred
+   :witan/version "1.0"
+   :witan/input-schema {:population PopulationSchema}
+   :witan/param-schema {:last-proj-year s/Int}
+   :witan/output-schema {:loop-predicate s/Bool}
+   ;; :witan/predicate? true
+   :witan/exported? true}
+  [{:keys [population]} {:keys [last-proj-year]}]
+  {:loop-predicate (< (get-last-yr-from-popn population) last-proj-year)})
+
 (defworkflowfn select-starting-popn
   "Takes in a dataset of popn estimates and a year for the projection.
    Returns a dataset w/ the starting popn (popn for the previous year)."
@@ -35,3 +46,7 @@
         last-yr-data (i/query-dataset population {:year latest-yr})
         update-yr (i/replace-column :year (i/$map inc :year last-yr-data) last-yr-data)]
     {:population (i/conj-rows population update-yr)}))
+
+;; (defn looping-test
+;;   [inputs  params]
+;;   (loop ))

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -11,37 +11,27 @@
    :columns (mapv #(s/one [(second %)] (format "col %s" (name (first %)))) col-vec)
    s/Keyword s/Any})
 
-(def PopnSchema
+(def PopulationSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:popn s/Int]]))
 
 ;; Functions:
-(defworkflowfn ->starting-popn
+(defn get-last-yr-from-popn
+  "Takes in a dataset. Select the latest year and returns it.
+  Note: expect a :year column."
+  [popn]
+  (reduce max (i/$ :year popn)))
+
+(defworkflowfn select-starting-popn
   "Takes in a dataset of popn estimates and a year for the projection.
    Returns a dataset w/ the starting popn (popn for the previous year)."
   {:witan/name :ccm-core/get-starting-popn
    :witan/version "1.0"
-   :witan/input-schema {:popn PopnSchema}
+   :witan/input-schema {:population PopulationSchema}
    :witan/param-schema {:first-proj-year s/Int}
-   :witan/output-schema {:starting-popn PopnSchema}}
-  [{:keys [popn]} {:keys [first-proj-year]}]
-  (let [latest-yr (reduce max (i/$ :year popn))]
-    (if (>= latest-yr first-proj-year)
-      {:starting-popn (i/query-dataset popn {:year (dec latest-yr)})}
-      (throw (Exception.
-              (format "The latest year in the base popn (%d) is expected to be greater than %d"
-                      latest-yr first-proj-year))))))
-
-(defworkflowfn ccm-core
-  "Takes in a dataset of popn estimates, a first year
-   and last year. Implement the looping to output the projections
-   for the range of years between the first and last year."
-  {:witan/name :ccm-core/exec-core-ccm
-   :witan/version "1.0"
-   :witan/input-schema {:popn PopnSchema}
-   :witan/param-schema {:first-proj-year s/Int
-                        :last-proj-year s/Int}
-   :witan/output-schema {:starting-popn PopnSchema} ;; TO BE UPDATED
-   :witan/exported? true}
-  [inputs params]
-  (->starting-popn inputs params))
+   :witan/output-schema {:population PopulationSchema}}
+  [{:keys [population]} {:keys [first-proj-year]}]
+  (let [latest-yr (get-last-yr-from-popn population)
+        last-yr-data (i/query-dataset population {:year latest-yr})
+        update-yr (i/replace-column :year (i/$map inc :year last-yr-data) last-yr-data)]
+    {:population (i/conj-rows population update-yr)}))

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -47,6 +47,12 @@
         update-yr (i/replace-column :year (i/$map inc :year last-yr-data) last-yr-data)]
     {:population (i/conj-rows population update-yr)}))
 
-;; (defn looping-test
-;;   [inputs  params]
-;;   (loop ))
+(defn looping-test
+  [inputs params]
+  (loop [inputs inputs
+         params params]
+    (let [inputs' (select-starting-popn inputs params)]
+      (println (format "Projecting for year %d..." (get-last-yr-from-popn (:population inputs'))))
+      (if (:loop-predicate (keep-looping? inputs' params))
+        (recur inputs' params)
+        (:population inputs')))))

--- a/src/witan/models/load_data.clj
+++ b/src/witan/models/load_data.clj
@@ -5,7 +5,7 @@
             [schema.coerce :as coerce]
             [schema.core :as s]
             [clojure.core.matrix.dataset :as ds]
-            [witan.models.dem.ccm.core.projection-loop :refer [PopnSchema]]
+            [witan.models.dem.ccm.core.projection-loop :refer [PopulationSchema]]
             [witan.models.dem.ccm.fert.hist-asfr-age :refer [BirthsDataSchema
                                                              AtRiskPopnSchema ]]))
 
@@ -96,10 +96,15 @@
   {:column-names (apply-col-names-schema HistBirthsEst csv-data)
    :columns (vec (apply-row-schema HistBirthsEst csv-data))})
 
-(defmethod apply-rec-coercion :popn
+(defmethod apply-rec-coercion :population
   [data-info csv-data]
-  {:column-names (apply-col-names-schema PopnSchema csv-data)
-   :columns (vec (apply-row-schema PopnSchema csv-data))})
+  {:column-names (apply-col-names-schema PopulationSchema csv-data)
+   :columns (vec (apply-row-schema PopulationSchema csv-data))})
+
+(defmethod apply-rec-coercion :hist-popn-estimates
+  [data-info csv-data]
+  {:column-names (apply-col-names-schema PopulationSchema csv-data)
+   :columns (vec (apply-row-schema PopulationSchema csv-data))})
 
 (defn dataset-after-coercion
   [{:keys [column-names columns]}]

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -4,13 +4,14 @@
             [clojure.test :as t]
             [clojure.string :as str]
             [clojure.core.matrix.dataset :as ds]
+            [clojure.core.matrix :as m]
             [incanter.core :as i]
             [witan.models.load-data :as ld]))
 
 ;; Load testing data
 ;; NEED TO GET THE RIGHT INPUT -> mye.est
 (def data-inputs (ld/load-datasets
-                  {:popn
+                  {:population
                    "resources/test_data/bristol_hist_popn_est.csv"}))
 
 (def params {:first-proj-year 2014
@@ -21,16 +22,9 @@
   (= (set coll1) (set coll2)))
 
 ;; Tests:
-(deftest ->starting-popn-test
+(deftest select-starting-popn-test
   (testing "The starting popn is returned"
-    (let [get-start-popn (->starting-popn data-inputs params)]
-      (is (same-coll? [:starting-popn :popn] (keys get-start-popn)))
+    (let [get-start-popn (select-starting-popn data-inputs params)]
       (is (same-coll? [:gss-code :sex :age :year :popn]
-                      (ds/column-names (:starting-popn get-start-popn))))
-      (is (same-coll? [2013] (set (i/$ :year (:starting-popn
-                                              (->starting-popn data-inputs params)))))))))
-
-(deftest ccm-core-test
-  (testing "The intermediary outputs are added to the global map"
-    (let [exec-core (ccm-core data-inputs params)]
-      (is (contains? exec-core :starting-popn)))))
+                      (ds/column-names (:population get-start-popn))))
+      (is (= 2015 (get-last-yr-from-popn (:population get-start-popn)))))))

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -15,7 +15,7 @@
                    "resources/test_data/bristol_hist_popn_est.csv"}))
 
 (def params {:first-proj-year 2014
-             :last-proj-year 2041})
+             :last-proj-year 2017})
 
 ;; Useful fn:
 (defn- same-coll? [coll1 coll2]


### PR DESCRIPTION
Change key name, change function name, remove ccm-core function, append starting population to the historical dataset.

Note: the last "starting population" appended to `:population` can easily be identified by its year -> no need to tag it.
