### PR TITLE
The remove-deaths step of the CCM core

### DIFF
--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -26,64 +26,93 @@
 
 (defworkflowfn select-starting-popn
   "Takes in a dataset of popn estimates.
-   Returns a dataset where the last year's population from the input data
-   is appended as the starting population for the next year's projection"
+   Returns a dataset of the starting population for the next year's projection."
   {:witan/name :ccm-core/get-starting-popn
    :witan/version "1.0"
    :witan/input-schema {:population PopulationSchema}
    :witan/param-schema {:_ nil}
-   :witan/output-schema {:population PopulationSchema}}
+   :witan/output-schema {:latest-yr-popn PopulationSchema}}
   [{:keys [population]} _]
   (let [latest-yr (get-last-yr-from-popn population)
         last-yr-data (i/query-dataset population {:year latest-yr})
         update-yr (i/replace-column :year (i/$map inc :year last-yr-data) last-yr-data)]
-    {:population (ds/join-rows population update-yr)}))
+    {:latest-yr-popn update-yr}))
 
 (defworkflowfn age-on
-  "Takes in a dataset of popn estimates.
-   Returns a dataset where the last year's population is aged on 1 year.
+  "Takes in a dataset with the starting-population.
+   Returns a dataset where the population is aged on 1 year.
    91 year olds are added to the 90 year olds in the aged-on popn."
   {:witan/name :ccm-cor/age-on
    :witan/version "1.0"
-   :witan/input-schema {:population PopulationSchema}
+   :witan/input-schema {:latest-yr-popn PopulationSchema}
    :witan/param-schema {:_ nil}
-   :witan/output-schema {:population PopulationSchema}}
-  [{:keys [population]} _]
-  (let [latest-yr (get-last-yr-from-popn population)
-        last-yr-data (i/query-dataset population {:year latest-yr})
-        prev-yrs-data (i/query-dataset population {:year {:$ne latest-yr}})
-        aged-on (i/replace-column :age (i/$map
+   :witan/output-schema {:latest-yr-popn PopulationSchema}}
+  [{:keys [latest-yr-popn]} _]
+  (let [aged-on (i/replace-column :age (i/$map
                                         (fn [v] (if (< v 90) (inc v) v))
-                                        :age last-yr-data) last-yr-data)
+                                        :age latest-yr-popn) latest-yr-popn)
         grouped (wds/rollup :sum :popn [:gss-code :sex :age :year] aged-on)]
-    {:population (ds/join-rows prev-yrs-data grouped)}))
+    {:latest-yr-popn grouped}))
 
 (defworkflowfn add-births
-  "Takes in dataset of aged on popn estimates and dataset of births 
-   by sex & gss code for latest year in popn dataset.
+  "Takes in a dataset of aged on popn and dataset of births by sex & gss code.
    Returns a dataset where the births output from the fertility module is
-   appended to the latest year in the popn dataset."
+   appended to the aged-on population, adding age groups 0."
   {:witan/name :ccm-core/add-births
    :witan/version "1.0"
-   :witan/input-schema {:population PopulationSchema :births BirthsBySexSchema}
+   :witan/input-schema {:latest-yr-popn PopulationSchema :births BirthsBySexSchema}
    :witan/param-schema {:_ nil}
-   :witan/output-schema {:population PopulationSchema}}
-  [{:keys [population births]} _]
-  (let [latest-yr (get-last-yr-from-popn population)
+   :witan/output-schema {:latest-yr-popn PopulationSchema}}
+  [{:keys [latest-yr-popn births]} _]
+  (let [latest-yr (get-last-yr-from-popn latest-yr-popn)
         update-births (-> births
                           (ds/add-column :age (repeat 0))
                           (ds/add-column :year (repeat latest-yr))
                           (ds/rename-columns {:births :popn}))]
-    {:population (ds/select-columns (ds/join-rows population update-births)
-                                    [:gss-code :sex :age :year :popn])}))
+    {:latest-yr-popn (ds/select-columns (ds/join-rows latest-yr-popn update-births)
+                                        [:gss-code :sex :age :year :popn])}))
+
+(defworkflowfn remove-deaths
+  "Takes in a dataset of aged on popn with births added, and a dataset
+   of deaths by sex.
+   Returns a dataset where the deaths output from the mortality module is
+   subtracted from the popn dataset."
+  {:witan/name :ccm-core/remove-deaths
+   :witan/version "1.0"
+   :witan/input-schema {:latest-yr-popn PopulationSchema :deaths DeathsSchema}
+   :witan/param-schema {:_ nil}
+   :witan/output-schema {:latest-yr-popn PopulationSchema}}
+  [{:keys [latest-yr-popn deaths]} _]
+  (let [deaths-ds (ds/select-columns deaths [:gss-code :sex :age :deaths])
+        popn-deaths (i/$join [[:gss-code :sex :age] [:gss-code :sex :age]]
+                             latest-yr-popn deaths-ds)
+        survived-popn (-> (i/replace-column :popn (i/$map (fn [popn deaths] (- popn deaths))
+                                                          [:popn :deaths] popn-deaths) popn-deaths)
+                          (ds/select-columns [:gss-code :sex :age :year :popn]))]
+    {:latest-yr-popn survived-popn}))
+
+(defworkflowfn join-popn-latest-yr
+  "Takes in a dataset of popn for previous years and a dataset of
+   projected population for the next year of projection.
+   Returns a datasets that appends the second dataset to the first one."
+  {:witan/name :ccm-core/join-yrs
+   :witan/version "1.0"
+   :witan/input-schema {:latest-yr-popn PopulationSchema :population PopulationSchema}
+   :witan/param-schema {:_ nil}
+   :witan/output-schema {:population PopulationSchema}}
+  [{:keys [latest-yr-popn population]} _]
+  {:population (ds/join-rows population latest-yr-popn)})
 
 (defn looping-test
   [inputs params]
   (loop [inputs inputs]
     (let [inputs' (->> (select-starting-popn inputs)
                        (age-on)
-                       (add-births))]
-      (println (format "Projecting for year %d..." (get-last-yr-from-popn (:population inputs'))))
+                       (add-births)
+                       (remove-deaths)
+                       (join-popn-latest-yr))]
+      (println (format "Projecting for year %d..."
+                       (get-last-yr-from-popn (:latest-yr-popn inputs'))))
       (if (:loop-predicate (keep-looping? inputs' params))
         (recur inputs')
         (:population inputs')))))

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -44,7 +44,8 @@
 (defworkflowfn age-on
   "Takes in a dataset with the starting-population.
    Returns a dataset where the population is aged on 1 year.
-   91 year olds are added to the 90 year olds in the aged-on popn."
+   Last year's 89 year olds are aged on and added to this year's
+   90+ age group (represented in code as age 90)"
   {:witan/name :ccm-cor/age-on
    :witan/version "1.0"
    :witan/input-schema {:latest-yr-popn PopulationSchema}

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -7,36 +7,39 @@
             [witan.datasets :as wds]
             [witan.models.dem.ccm.schemas :refer :all]))
 
-(defn get-last-yr-from-popn
-  "Takes in a dataset. Select the latest year and returns it.
-  Note: expect a :year column."
-  [popn]
-  (reduce max (i/$ :year popn)))
-
 (defworkflowfn keep-looping?
   {:witan/name :ccm-core/ccm-loop-pred
    :witan/version "1.0"
    :witan/input-schema {:population PopulationSchema :loop-year s/Int}
    :witan/param-schema {:last-proj-year s/Int}
    :witan/output-schema {:loop-predicate s/Bool}
-   ;; :witan/predicate? true
    :witan/exported? true}
   [{:keys [loop-year]} {:keys [last-proj-year]}]
   {:loop-predicate (< loop-year last-proj-year)})
+
+(defworkflowfn prepare-inputs
+  {:witan/name :ccm-core/get-starting-popn
+   :witan/version "1.0"
+   :witan/input-schema {:population PopulationSchema}
+   :witan/param-schema {:_ nil}
+   :witan/output-schema {:loop-year s/Int :latest-yr-popn PopulationSchema}}
+  [{:keys [population]} _]
+  (let [last-yr (reduce max (i/$ :year population))
+        last-yr-popn (i/query-dataset population {:year last-yr})]
+    {:loop-year last-yr :latest-yr-popn last-yr-popn}))
 
 (defworkflowfn select-starting-popn
   "Takes in a dataset of popn estimates.
    Returns a dataset of the starting population for the next year's projection."
   {:witan/name :ccm-core/get-starting-popn
    :witan/version "1.0"
-   :witan/input-schema {:population PopulationSchema}
+   :witan/input-schema {:latest-yr-popn PopulationSchema :population PopulationSchema
+                        :loop-year s/Int}
    :witan/param-schema {:_ nil}
    :witan/output-schema {:latest-yr-popn PopulationSchema :loop-year s/Int}}
-  [{:keys [population]} _]
-  (let [latest-yr (get-last-yr-from-popn population)
-        last-yr-data (i/query-dataset population {:year latest-yr})
-        update-yr (i/replace-column :year (i/$map inc :year last-yr-data) last-yr-data)]
-    {:latest-yr-popn update-yr :loop-year (inc latest-yr)}))
+  [{:keys [latest-yr-popn population loop-year]} _]
+  (let [update-yr (i/replace-column :year (i/$map inc :year latest-yr-popn) latest-yr-popn)]
+    {:latest-yr-popn update-yr :loop-year (inc loop-year)}))
 
 (defworkflowfn age-on
   "Takes in a dataset with the starting-population.
@@ -121,16 +124,18 @@
   [{:keys [latest-yr-popn population]} _]
   {:population (ds/join-rows population latest-yr-popn)})
 
+
 (defn looping-test
   [inputs params]
-  (loop [inputs inputs]
-    (let [inputs' (->> (select-starting-popn inputs)
-                       (age-on)
-                       (add-births)
-                       (remove-deaths)
-                       (apply-migration)
-                       (join-popn-latest-yr))]
-      (println (format "Projecting for year %d..." (:loop-year inputs')))
-      (if (:loop-predicate (keep-looping? inputs' params))
-        (recur inputs')
-        (:population inputs')))))
+  (let [prepared-inputs (prepare-inputs inputs)]
+    (loop [inputs prepared-inputs]
+      (let [inputs' (->> (select-starting-popn inputs)
+                         (age-on)
+                         (add-births)
+                         (remove-deaths)
+                         (apply-migration)
+                         (join-popn-latest-yr))]
+        (println (format "Projecting for year %d..." (:loop-year inputs')))
+        (if (:loop-predicate (keep-looping? inputs' params))
+          (recur inputs')
+          (:population inputs'))))))

--- a/src/witan/models/dem/ccm/schemas.clj
+++ b/src/witan/models/dem/ccm/schemas.clj
@@ -22,11 +22,11 @@
                   (s/one datatype fieldname)))
         (:column-names col-schema)))
 
-;;Define schemas 
-;;For core CCM projection loop      
+;;Define schemas
+;;For core CCM projection loop
 (def HistBirthsEstSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:district s/Str] [:sex s/Str] [:age s/Int]
-                           [:var s/Str] [:year s/Int] [:estimate s/Num]]))   
+                           [:var s/Str] [:year s/Int] [:estimate s/Num]]))
 
 (def PopulationSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
@@ -38,7 +38,7 @@
 
 (def DeathsSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:year s/Int]
-                           [:death-rate s/Num] [:popn s/Int] [:deaths s/Num]]))
+                           [:death-rate s/Num] [:popn s/Num] [:deaths s/Num]]))
 
 (def NetMigrationSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:net-mig s/Num]]))

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -10,15 +10,16 @@
 
 ;; Load testing data
 ;; NEED TO GET THE RIGHT INPUT -> mye.est
-(def data-inputs (ld/load-datasets
-                  {:population
-                   "resources/test_data/bristol_hist_popn_est.csv"
-                   :births
-                   "resources/test_data/handmade_outputs/bristol_fertility_module_handmade_output.csv"
-                   :deaths
-                   "resources/test_data/handmade_outputs/bristol_mortality_module_handmade_output.csv"
-                   :net-migration
-                   "resources/test_data/handmade_outputs/bristol_migration_module_handmade_output.csv"}))
+(def data-inputs (prepare-inputs
+                  (ld/load-datasets
+                   {:population
+                    "resources/test_data/bristol_hist_popn_est.csv"
+                    :births
+                    "resources/test_data/handmade_outputs/bristol_fertility_module_handmade_output.csv"
+                    :deaths
+                    "resources/test_data/handmade_outputs/bristol_mortality_module_handmade_output.csv"
+                    :net-migration
+                    "resources/test_data/handmade_outputs/bristol_migration_module_handmade_output.csv"})))
 
 (def params {:first-proj-year 2014
              :last-proj-year 2015})
@@ -68,7 +69,8 @@
 
 (deftest add-births-test
   (testing "Newborns are correctly added to projection year popn."
-    (let [popn-with-births (:latest-yr-popn (add-births (age-on (select-starting-popn data-inputs))))
+    (let [popn-with-births (:latest-yr-popn
+                            (add-births (age-on (select-starting-popn data-inputs))))
           latest-yr (get-last-yr-from-popn popn-with-births)
           latest-newborns (i/query-dataset popn-with-births {:year latest-yr :age 0})]
       (is (= 2 (first (:shape latest-newborns))))

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -18,10 +18,10 @@
                    :deaths
                    "resources/test_data/handmade_outputs/bristol_mortality_module_handmade_output.csv"
                    :net-migration
-                   "resources/test_data/handmade/outputs/bristol_migration_module_handmade_output.csv"}))
+                   "resources/test_data/handmade_outputs/bristol_migration_module_handmade_output.csv"}))
 
 (def params {:first-proj-year 2014
-             :last-proj-year 2017})
+             :last-proj-year 2015})
 
 ;; Useful fns:
 (defn- same-coll? [coll1 coll2]
@@ -33,8 +33,11 @@
 (def sum-popn (fn [popn year age]
                 (apply + (i/$ :popn (i/query-dataset popn
                                                      {:year year :age age})))))
-(def get-popn (fn [ds popn year age sex]
-                (i/$ popn (i/query-dataset ds {:year year :age age :sex sex}))))
+(def get-popn (fn
+                ([ds popn age sex]
+                 (i/$ popn (i/query-dataset ds {:age age :sex sex})))
+                ([ds popn year age sex]
+                   (i/$ popn (i/query-dataset ds {:year year :age age :sex sex})))))
 
 ;; Tests:
 (deftest select-starting-popn-test
@@ -79,5 +82,16 @@
           popn-with-births (add-births aged-on-popn)
           popn-wo-deaths (remove-deaths popn-with-births)]
       (is (= (- (get-popn (:latest-yr-popn popn-with-births) :popn 2015 0 "F")
-                (get-popn (:deaths popn-with-births) :deaths 2015 0 "F"))
+                (get-popn (:deaths popn-with-births) :deaths 0 "F"))
              (get-popn (:latest-yr-popn popn-wo-deaths) :popn 2015 0 "F"))))))
+
+(deftest apply-migration-test
+  (testing "The migrants are added to the popn."
+    (let [starting-popn (select-starting-popn data-inputs)
+          aged-on-popn (age-on starting-popn)
+          popn-with-births (add-births aged-on-popn)
+          popn-wo-deaths (remove-deaths popn-with-births)
+          popn-with-mig (apply-migration popn-wo-deaths)]
+      (is (= (+ (get-popn (:latest-yr-popn popn-wo-deaths) :popn 2015 0 "F")
+                (get-popn (:net-migration popn-wo-deaths) :net-mig 0 "F"))
+             (get-popn (:latest-yr-popn popn-with-mig) :popn 2015 0 "F"))))))

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -46,7 +46,7 @@
     (let [get-start-popn (select-starting-popn data-inputs)]
       (is (same-coll? [:gss-code :sex :age :year :popn]
                       (ds/column-names (:latest-yr-popn get-start-popn))))
-      (is (= 2015 (get-last-yr-from-popn (:latest-yr-popn get-start-popn))))
+      (is (true? (every? #(= % 2015) (i/$ :year (:latest-yr-popn get-start-popn)))))
       ;; Total number of 15 yrs old in 2015:
       (is (= 4386 (apply + (i/$ :popn
                                 (i/query-dataset (:latest-yr-popn get-start-popn)
@@ -69,9 +69,9 @@
 
 (deftest add-births-test
   (testing "Newborns are correctly added to projection year popn."
-    (let [popn-with-births (:latest-yr-popn
-                            (add-births (age-on (select-starting-popn data-inputs))))
-          latest-yr (get-last-yr-from-popn popn-with-births)
+    (let [births-added (add-births (age-on (select-starting-popn data-inputs)))
+          popn-with-births (:latest-yr-popn births-added)
+          latest-yr (:loop-year births-added)
           latest-newborns (i/query-dataset popn-with-births {:year latest-yr :age 0})]
       (is (= 2 (first (:shape latest-newborns))))
       (is (fp-equals? (+ 3185.29154299837 3344.55612014829)


### PR DESCRIPTION
- Remove deaths
- Add migrants
- Split the previous years population and the next year projection within the loop. Extra key `:latest-yr-popn`
- Keep track of the current year within the loop. Extra key `:loop-year`.
