### PR TITLE
Project asmr using average fixed methods

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [net.mikera/core.matrix "0.51.0"]
                  [witan.workspace-executor "0.1.3"]
                  [kixi/incanter-core "1.9.1-p0-3bf644a"]
-                 [witan.workspace-api "0.1.3"]]
+                 [witan.workspace-api "0.1.4"]]
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}
   :exclusions [prismatic/schema org.clojure/clojure])

--- a/src/witan/models/dem/ccm/schemas.clj
+++ b/src/witan/models/dem/ccm/schemas.clj
@@ -107,3 +107,6 @@
 (def HistASMRSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:district s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:death-rate double]]))
+
+(def ProjFixedASMRSchema
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:proj-death-rate double]]))

--- a/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
+++ b/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
@@ -1,10 +1,11 @@
-(ns witan.models.dem.ccm.mort.calc-hist-asmr-test
-  (:require [witan.models.dem.ccm.mort.calc-hist-asmr :refer :all]
+(ns witan.models.dem.ccm.mort.mortality-mvp-test
+  (:require [witan.models.dem.ccm.mort.mortality-mvp :refer :all]
             [witan.models.load-data :as ld]
             [clojure.test :refer :all]
             [incanter.core :as i]
             [clojure.core.matrix.dataset :as ds]
-            [witan.datasets :as wds]))
+            [witan.datasets :as wds]
+            [witan.models.dem.ccm.core.projection-loop-test :as plt]))
 
 (defn- fp-equals? [x y ε] (< (Math/abs (- x y)) ε))
 
@@ -29,10 +30,25 @@
   (testing "Death rates are calculated correctly."
     (let [hist-asmr-r (ds/rename-columns historic-asmr-r {:death-rate :death-rate-r})
           joined-asmr (-> hist-asmr-inputs
-                          (calc-historic-asmr)
-                          (:historic-asmr)
+                          calc-historic-asmr
+                          :historic-asmr
                           (wds/join hist-asmr-r [:gss-code :district :sex :age :year]))]
       (is (every? #(fp-equals? (i/sel joined-asmr :rows % :cols :death-rate-r)
                                (i/sel joined-asmr :rows % :cols :death-rate)
                                0.0000000001)
                   (range (first (:shape joined-asmr))))))))
+
+(def params {:number-of-years-mort 5 :jumpoff-year-mort 2015})
+
+(deftest project-asmr-test
+  (testing "mortality rates projected correctly"
+    (let [projected-asmr (-> hist-asmr-inputs
+                             calc-historic-asmr
+                             (project-asmr params)
+                             :initial-projected-mortality-rates)]
+      (is (fp-equals? 2.049763E-03
+                      (nth (plt/get-popn projected-asmr :proj-death-rate 0 "F") 0)
+                      0.000000001))
+      (is (fp-equals? 0.2068731
+                      (nth (plt/get-popn projected-asmr :proj-death-rate 90 "M") 0)
+                      0.0000001)))))


### PR DESCRIPTION
Projects age specific mortality rates (ASMR) for the MVP generic cohort component model using the following methods:
- method for calculating projected rates in jump off year = average i.e. take an average of some of the historic data
- method for projecting death rates beyond jump off year = fixed i.e. keep applying the averaged rates

Also:
- updates witan.workspace-api version
