### PR TITLE
Remove redundant population key

### DIFF
--- a/src/witan/models/dem/ccm/fert/fertility_mvp.clj
+++ b/src/witan/models/dem/ccm/fert/fertility_mvp.clj
@@ -125,7 +125,7 @@
   {:witan/name :ccm-fert/project-births-fixed-rates
    :witan/version "1.0"
    :witan/input-schema {:initial-projected-fertility-rates ProjFixedASFRSchema
-                        :population-at-risk PopulationSchema}
+                        :population-at-risk HistPopulationSchema}
    :witan/output-schema {:births-by-age-sex-mother BirthsAgeSexMotherSchema}}
   [{:keys [initial-projected-fertility-rates population-at-risk]} _]
   (let [projected-births (cf/project-component-fixed-rates
@@ -196,7 +196,7 @@
   {:witan/name :ccm-fert/births-projection
    :witan/version "1.0"
    :witan/input-schema {:initial-projected-fertility-rates ProjFixedASFRSchema
-                        :population-at-risk PopulationSchema}
+                        :population-at-risk HistPopulationSchema}
    :witan/param-schema {:proportion-male-newborns double}
    :witan/output-schema {:births-by-age-sex-mother BirthsAgeSexMotherSchema
                          :births BirthsBySexSchema}}

--- a/src/witan/models/dem/ccm/mort/mortality_mvp.clj
+++ b/src/witan/models/dem/ccm/mort/mortality_mvp.clj
@@ -76,7 +76,7 @@
   {:witan/name :ccm-mort/project-deaths-fixed-rates
    :witan/version "1.0"
    :witan/input-schema {:initial-projected-mortality-rates ProjFixedASMRSchema
-                        :population-at-risk PopulationSchema}
+                        :population-at-risk HistPopulationSchema}
    :witan/output-schema {:deaths DeathsOutputSchema}}
   [{:keys [initial-projected-mortality-rates population-at-risk]} _]
   {:deaths

--- a/src/witan/models/dem/ccm/schemas.clj
+++ b/src/witan/models/dem/ccm/schemas.clj
@@ -27,10 +27,6 @@
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:var s/Str] [:year s/Int] [:estimate double]]))
 
-(def PopulationSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:popn double]]))
-
 (def DeathsSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:deaths double]]))

--- a/src/witan/models/load_data.clj
+++ b/src/witan/models/load_data.clj
@@ -60,15 +60,15 @@
   {:column-names (apply-col-names-schema BirthsDataSchema csv-data)
    :columns (vec (apply-row-schema BirthsDataSchema csv-data))})
 
-(defmethod apply-record-coercion :population
+(defmethod apply-record-coercion :historic-population
   [data-info csv-data]
-  {:column-names (apply-col-names-schema PopulationSchema csv-data)
-   :columns (vec (apply-row-schema PopulationSchema csv-data))})
+  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
+   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
 
 (defmethod apply-record-coercion :end-population
   [data-info csv-data]
-  {:column-names (apply-col-names-schema PopulationSchema csv-data)
-   :columns (vec (apply-row-schema PopulationSchema csv-data))})
+  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
+   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
 
 (defmethod apply-record-coercion :births
   [data-info csv-data]
@@ -136,6 +136,11 @@
    :columns (vec (apply-row-schema BirthsSchema csv-data))})
 
 (defmethod apply-record-coercion :historic-population
+  [data-info csv-data]
+  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
+   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
+
+(defmethod apply-record-coercion :population-at-risk
   [data-info csv-data]
   {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
    :columns (vec (apply-row-schema HistPopulationSchema csv-data))})

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -11,9 +11,7 @@
 
 ;; Load testing data
 (def data-inputs (ld/load-datasets
-                  {:population
-                   "test_data/model_inputs/core/bristol_hist_popn_est.csv"
-                   :ons-proj-births-by-age-mother
+                  {:ons-proj-births-by-age-mother
                    "test_data/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
                    :historic-births
                    "test_data/model_inputs/fert/bristol_hist_births_mye.csv"

--- a/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
+++ b/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
@@ -12,16 +12,14 @@
 ;; Test inputs ;;
 ;;;;;;;;;;;;;;;;;
 
-(def fertility-inputs (-> {:ons-proj-births-by-age-mother
+(def fertility-inputs (ld/load-datasets {:ons-proj-births-by-age-mother
                            "test_data/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
                            :historic-births
                            "test_data/model_inputs/fert/bristol_hist_births_mye.csv"
                            :historic-population
                            "test_data/model_inputs/bristol_hist_popn_mye.csv"
-                           :population ;;this actually comes from the proj loop but for test use this csv
-                           "test_data/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"}
-                          ld/load-datasets
-                          (clojure.set/rename-keys {:population :population-at-risk})))
+                           :population-at-risk ;;this actually comes from the proj loop but for test use this csv
+                           "test_data/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"}))
 
 (def params {:fert-last-yr 2014 :proportion-male-newborns (double (/ 105 205))})
 

--- a/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
+++ b/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
@@ -14,16 +14,14 @@
 ;;historic-births = historic.mort.age0 in R code
 ;;historic-popn = MYE-Est in R code
 (def hist-asmr-inputs
-  (-> {:population ;;this actually comes from the proj loop but for test use this csv
-       "test_data/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"
-       :historic-deaths
+  (ld/load-datasets {:historic-deaths
        "test_data/model_inputs/mort/bristol_hist_deaths_mye.csv"
        :historic-births
        "test_data/model_inputs/fert/bristol_hist_births_mye.csv"
        :historic-population
-       "test_data/model_inputs/bristol_hist_popn_mye.csv"}
-      ld/load-datasets
-      (clojure.set/rename-keys {:population :population-at-risk})))
+       "test_data/model_inputs/bristol_hist_popn_mye.csv"
+       :population-at-risk ;;this actually comes from the proj loop but for test use this csv
+       "test_data/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"}))
 
 ;;Output from R calc-historic-asmr function for comparison
 (def historic-asmr-r (:historic-asmr (ld/load-dataset


### PR DESCRIPTION
The keys `:population` and `:historic-population` actually represent the same data.

-> replace `:population` by `:historic-population` that seem to be slightly more meaningful
-> implement those changes throughout the code/schema
