### PR TITLE
Change year ranges for start/end years.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # witan.models.demography
 
-
-[![circle-ci shield](https://circleci.com/gh/:owner/:repo.svg?style=shield&circle-token=:circle-token)](https://github.com/MastodonC/witan.models.demography)
+[![Build Status](https://circleci.com/gh/MastodonC/witan.models.demography.svg?style=shield)](https://circleci.com/gh/MastodonC/witan.models.demography) [![Dependencies Status](https://jarkeeper.com/MastodonC/witan.models.demography/status.svg)](https://jarkeeper.com/MastodonC/witan.models.demography)
 
 
 ## Description

--- a/src/witan/models/dem/ccm/components_functions.clj
+++ b/src/witan/models/dem/ccm/components_functions.clj
@@ -12,8 +12,8 @@
   and the jumpoff year. Returns a dataset where the column to be averaged contains
   the averages for all the years of interest and is renamed to avg-name."
   [historical-data col-to-avg avg-name start-yr-avg end-yr-avg]
-  ;; start-yr-range should be >= than the earliest year in historical-data
-  ;; end-yr-range should be <= than the latest year in historical-data
+  ;; (s/validate (s/pred (>= % historical-data-earliest-yr)) start-yr-range)
+  ;; (s/validate (s/pred (<= % historical-data-latest-yr)) end-yr-range)
   (-> (i/query-dataset historical-data
                        {:year {:$gte start-yr-avg
                                :$lte end-yr-avg}})

--- a/src/witan/models/dem/ccm/components_functions.clj
+++ b/src/witan/models/dem/ccm/components_functions.clj
@@ -11,14 +11,14 @@
   a name to rename the average column, a number of years to average on
   and the jumpoff year. Returns a dataset where the column to be averaged contains
   the averages for all the years of interest and is renamed to avg-name."
-  [historical-data col-to-avg avg-name number-of-years jumpoff-year]
-  (let [last-yr-data (dec jumpoff-year)
-        start-year-data (inc (- last-yr-data number-of-years))]
-    (-> (i/query-dataset historical-data
-                         {:year {:$gte start-year-data
-                                 :$lte last-yr-data}})
-        (ds/rename-columns {col-to-avg avg-name})
-        (wds/rollup :mean avg-name [:gss-code :sex :age]))))
+  [historical-data col-to-avg avg-name start-yr-avg end-yr-avg]
+  ;; start-yr-range should be >= than the earliest year in historical-data
+  ;; end-yr-range should be <= than the latest year in historical-data
+  (-> (i/query-dataset historical-data
+                       {:year {:$gte start-yr-avg
+                               :$lte end-yr-avg}})
+      (ds/rename-columns {col-to-avg avg-name})
+      (wds/rollup :mean avg-name [:gss-code :sex :age])))
 
 ;; Project component for fixed rates:
 (defn project-component-fixed-rates

--- a/src/witan/models/dem/ccm/fert/fertility_mvp.clj
+++ b/src/witan/models/dem/ccm/fert/fertility_mvp.clj
@@ -108,15 +108,16 @@
   {:witan/name :ccm-fert/project-asfr-finalyrhist-fixed
    :witan/version "1.0"
    :witan/input-schema {:historic-asfr HistASFRSchema}
-   :witan/param-schema {:fert-last-yr s/Int}
+   :witan/param-schema {:fert-last-yr s/Int :start-yr-avg-fert s/Int
+                        :end-yr-avg-fert s/Int}
    :witan/output-schema {:initial-projected-fertility-rates ProjFixedASFRSchema}}
-  [{:keys [historic-asfr]} {:keys [fert-last-yr]}]
+  [{:keys [historic-asfr]} {:keys [fert-last-yr start-yr-avg-fert end-yr-avg-fert]}]
   {:initial-projected-fertility-rates
    (cf/jumpoffyr-method-average historic-asfr
                                 :fert-rate
                                 :fert-rate
-                                2013
-                                2014)})
+                                start-yr-avg-fert
+                                end-yr-avg-fert)})
 
 (defworkflowfn project-births-from-fixed-rates
   "Takes a dataset with population at risk from the current year of the projection
@@ -181,7 +182,8 @@
    :witan/input-schema {:ons-proj-births-by-age-mother BirthsAgeSexMotherSchema
                         :historic-population HistPopulationSchema
                         :historic-births BirthsSchema}
-   :witan/param-schema {:fert-last-yr s/Int}
+   :witan/param-schema {:fert-last-yr s/Int :start-yr-avg-fert s/Int
+                        :end-yr-avg-fert s/Int}
    :witan/output-schema {:historic-asfr HistASFRSchema
                          :initial-projected-fertility-rates ProjFixedASFRSchema}}
   [input-data params]

--- a/src/witan/models/dem/ccm/fert/fertility_mvp.clj
+++ b/src/witan/models/dem/ccm/fert/fertility_mvp.clj
@@ -115,8 +115,8 @@
    (cf/jumpoffyr-method-average historic-asfr
                                 :fert-rate
                                 :fert-rate
-                                1
-                                (inc fert-last-yr))})
+                                2013
+                                2014)})
 
 (defworkflowfn project-births-from-fixed-rates
   "Takes a dataset with population at risk from the current year of the projection

--- a/src/witan/models/dem/ccm/mig/net_migration.clj
+++ b/src/witan/models/dem/ccm/mig/net_migration.clj
@@ -10,45 +10,45 @@
   {:witan/name :ccm-mig/proj-dom-in-mig
    :witan/version "1.0"
    :witan/input-schema {:domestic-in-migrants ComponentMYESchema}
-   :witan/param-schema {:number-of-years-mig s/Int :jumpoff-year-mig s/Int}
+   :witan/param-schema {:start-yr-avg-dom-mig s/Int :end-yr-avg-dom-mig s/Int}
    :witan/output-schema {:projected-domestic-in-migrants ProjDomInSchema}}
-  [{:keys [domestic-in-migrants]} {:keys [number-of-years-mig jumpoff-year-mig]}]
+  [{:keys [domestic-in-migrants]} {:keys [start-yr-avg-dom-mig end-yr-avg-dom-mig]}]
   {:projected-domestic-in-migrants
    (cf/jumpoffyr-method-average domestic-in-migrants :estimate
-                                :domestic-in number-of-years-mig jumpoff-year-mig)})
+                                :domestic-in start-yr-avg-dom-mig end-yr-avg-dom-mig)})
 
 (defworkflowfn project-domestic-out-migrants
   {:witan/name :ccm-mig/proj-dom-out-mig
    :witan/version "1.0"
    :witan/input-schema {:domestic-out-migrants ComponentMYESchema}
-   :witan/param-schema {:number-of-years-mig s/Int :jumpoff-year-mig s/Int}
+   :witan/param-schema {:start-yr-avg-dom-mig s/Int :end-yr-avg-dom-mig s/Int}
    :witan/output-schema {:projected-domestic-out-migrants ProjDomOutSchema}}
-  [{:keys [domestic-out-migrants]} {:keys [number-of-years-mig jumpoff-year-mig]}]
+  [{:keys [domestic-out-migrants]} {:keys [start-yr-avg-dom-mig end-yr-avg-dom-mig]}]
   {:projected-domestic-out-migrants
    (cf/jumpoffyr-method-average domestic-out-migrants :estimate
-                                :domestic-out number-of-years-mig jumpoff-year-mig)})
+                                :domestic-out start-yr-avg-dom-mig end-yr-avg-dom-mig)})
 
 (defworkflowfn project-international-in-migrants
   {:witan/name :ccm-mig/proj-inter-in-mig
    :witan/version "1.0"
    :witan/input-schema {:international-in-migrants ComponentMYESchema}
-   :witan/param-schema {:number-of-years-mig s/Int :jumpoff-year-mig s/Int}
+   :witan/param-schema {:start-yr-avg-inter-mig s/Int :end-yr-avg-inter-mig s/Int}
    :witan/output-schema {:projected-international-in-migrants ProjInterInSchema}}
-  [{:keys [international-in-migrants]} {:keys [number-of-years-mig jumpoff-year-mig]}]
+  [{:keys [international-in-migrants]} {:keys [start-yr-avg-inter-mig end-yr-avg-inter-mig]}]
   {:projected-international-in-migrants
    (cf/jumpoffyr-method-average international-in-migrants :estimate
-                                :international-in number-of-years-mig jumpoff-year-mig)})
+                                :international-in start-yr-avg-inter-mig end-yr-avg-inter-mig)})
 
 (defworkflowfn project-international-out-migrants
   {:witan/name :ccm-mig/proj-inter-out-mig
    :witan/version "1.0"
    :witan/input-schema {:international-out-migrants ComponentMYESchema}
-   :witan/param-schema {:number-of-years-mig s/Int :jumpoff-year-mig s/Int}
+   :witan/param-schema {:start-yr-avg-inter-mig s/Int :end-yr-avg-inter-mig s/Int}
    :witan/output-schema {:projected-international-out-migrants ProjInterOutSchema}}
-  [{:keys [international-out-migrants]} {:keys [number-of-years-mig jumpoff-year-mig]}]
+  [{:keys [international-out-migrants]} {:keys [start-yr-avg-inter-mig end-yr-avg-inter-mig]}]
   {:projected-international-out-migrants
    (cf/jumpoffyr-method-average international-out-migrants :estimate
-                                :international-out number-of-years-mig jumpoff-year-mig)})
+                                :international-out start-yr-avg-inter-mig end-yr-avg-inter-mig)})
 
 (defworkflowfn combine-into-net-flows
   {:witan/name :ccm-mig/combine-mig-flows
@@ -79,7 +79,8 @@
                         :domestic-in-migrants ComponentMYESchema
                         :international-out-migrants ComponentMYESchema
                         :international-in-migrants ComponentMYESchema}
-   :witan/param-schema {:number-of-years-mig s/Int :jumpoff-year-mig s/Int}
+   :witan/param-schema  {:start-yr-avg-dom-mig s/Int :end-yr-avg-dom-mig s/Int
+                         :start-yr-avg-inter-mig s/Int :end-yr-avg-inter-mig s/Int}
    :witan/output-schema {:projected-domestic-out-migrants ProjDomOutSchema
                          :projected-domestic-in-migrants ProjDomInSchema
                          :projected-international-out-migrants ProjInterOutSchema

--- a/src/witan/models/dem/ccm/mort/mortality_mvp.clj
+++ b/src/witan/models/dem/ccm/mort/mortality_mvp.clj
@@ -60,14 +60,14 @@
   {:witan/name :ccm-mort/project-asmr
    :witan/version "1.0"
    :witan/input-schema {:historic-asmr HistASMRSchema}
-   :witan/param-schema {:number-of-years-mort s/Int :jumpoff-year-mort s/Int}
+   :witan/param-schema {:start-yr-avg-mort s/Int :end-yr-avg-mort s/Int}
    :witan/output-schema {:initial-projected-mortality-rates ProjFixedASMRSchema}}
-  [{:keys [historic-asmr]} {:keys [number-of-years-mort jumpoff-year-mort]}]
+  [{:keys [historic-asmr]} {:keys [start-yr-avg-mort end-yr-avg-mort]}]
   {:initial-projected-mortality-rates (cf/jumpoffyr-method-average historic-asmr
                                                                    :death-rate
                                                                    :death-rate
-                                                                   number-of-years-mort
-                                                                   jumpoff-year-mort)})
+                                                                   start-yr-avg-mort
+                                                                   end-yr-avg-mort)})
 
 (defworkflowfn project-deaths-from-fixed-rates
   "Takes a dataset with population at risk from the current year of the projection
@@ -93,7 +93,7 @@
    :witan/input-schema {:historic-deaths DeathsSchema
                         :historic-births BirthsSchema
                         :historic-population HistPopulationSchema}
-   :witan/param-schema {:number-of-years-mort s/Int :jumpoff-year-mort s/Int}
+   :witan/param-schema {:start-yr-avg-mort s/Int :end-yr-avg-mort s/Int}
    :witan/output-schema {:historic-asmr HistASMRSchema
                          :initial-projected-mortality-rates ProjFixedASMRSchema}}
   [input-data params]

--- a/test/witan/models/dem/ccm/components_functions_test.clj
+++ b/test/witan/models/dem/ccm/components_functions_test.clj
@@ -35,28 +35,28 @@
   (testing "The function return the averages on the right year period"
     (let [r-results (:dom-in-averages dom-in-averages)
           clj-results (jumpoffyr-method-average (:domestic-in-migrants migration-data)
-                                                :estimate :domestic-in 12 2015)
+                                                :estimate :domestic-in 2003 2014)
           joined-averages (wds/join r-results clj-results [:gss-code :sex :age])]
       (is (every? #(fp-equals? (i/sel joined-averages :rows % :cols :domin)
                                (i/sel joined-averages :rows % :cols :domestic-in) 0.0000000001)
                   (range (first (:shape joined-averages))))))
     (let [r-results (:dom-out-averages dom-out-averages)
           clj-results (jumpoffyr-method-average (:domestic-out-migrants migration-data)
-                                                :estimate :domestic-out 12 2015)
+                                                :estimate :domestic-out 2003 2014)
           joined-averages (wds/join r-results clj-results [:gss-code :sex :age])]
       (is (every? #(fp-equals? (i/sel joined-averages :rows % :cols :domout)
                                (i/sel joined-averages :rows % :cols :domestic-out) 0.0000000001)
                   (range (first (:shape joined-averages))))))
     (let [r-results (:inter-out-averages inter-out-averages)
           clj-results (jumpoffyr-method-average (:international-out-migrants migration-data)
-                                                :estimate :international-out 12 2015)
+                                                :estimate :international-out 2003 2014)
           joined-averages (wds/join r-results clj-results [:gss-code :sex :age])]
       (is (every? #(fp-equals? (i/sel joined-averages :rows % :cols :intout)
                                (i/sel joined-averages :rows % :cols :international-out) 0.0000000001)
                   (range (first (:shape joined-averages))))))
     (let [r-results (:inter-in-averages inter-in-averages)
           clj-results (jumpoffyr-method-average (:international-in-migrants migration-data)
-                                                :estimate :international-in 12 2015)
+                                                :estimate :international-in 2003 2014)
           joined-averages (wds/join r-results clj-results [:gss-code :sex :age])]
       (is (every? #(fp-equals? (i/sel joined-averages :rows % :cols :intin)
                                (i/sel joined-averages :rows % :cols :international-in) 0.0000000001)

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -28,24 +28,41 @@
                    :international-out-migrants
                    "test_data/model_inputs/mig/bristol_hist_international_outmigrants.csv"}))
 
-(def params {:fert-last-yr 2014
-             :proportion-male-newborns (double (/ 105 205))
+(def params {;; Core module
              :first-proj-year 2014
              :last-proj-year 2015
-             :start-yr-avg-mort 2010 ;; should be >= earliest year in deaths data
-             :end-yr-avg-mort 2014 ;; should be <= mortality jumpoff year-1
-             :start-yr-avg-dom-mig 2003 ;; should be >=earliest year in domestic migrants data
-             :end-yr-avg-dom-mig 2014 ;; should be <= migration jumpoff year-1
-             :start-yr-avg-inter-mig 2003 ;; should be >=earliest year in international migrants data
-             :end-yr-avg-inter-mig 2014 ;; should be <= migration jumpoff year-1
-             })
+             ;; Fertility module
+             :fert-last-yr 2014
+             :start-yr-avg-fert 2013
+             :end-yr-avg-fert 2014 ;; (s/validate (s/eq :fert-last-yr) :end-yr-avg-fert)
+             :proportion-male-newborns (double (/ 105 205))
+             ;; Mortality module
+             ;; (s/validate (s/pred (>= % earliest-mort-yr)) :start-yr-avg-mort)
+             :start-yr-avg-mort 2010
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mort))) :end-yr-avg-mort)
+             :end-yr-avg-mort 2014
+             ;; Migration module
+             ;; (s/validate (s/pred (>= % earliest-dom-mig-yr)) :start-yr-avg-dom-mig)
+             :start-yr-avg-dom-mig 2003
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-dom-mig)
+             :end-yr-avg-dom-mig 2014
+             ;; (s/validate (s/pred (>= % earliest-inter-mig-yr)) :start-yr-avg-inter-mig)
+             :start-yr-avg-inter-mig 2003
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-inter-mig)
+             :end-yr-avg-inter-mig 2014})
 
-(def params-2040 {:fert-last-yr 2014
-                  :proportion-male-newborns (double (/ 105 205))
+(def params-2040 {;; Core module
                   :first-proj-year 2014
                   :last-proj-year 2040
+                  ;; Fertility module
+                  :fert-last-yr 2014
+                  :start-yr-avg-fert 2013
+                  :end-yr-avg-fert 2014
+                  :proportion-male-newborns (double (/ 105 205))
+                  ;; Mortality module
                   :start-yr-avg-mort 2010
                   :end-yr-avg-mort 2014
+                  ;; Migration module
                   :start-yr-avg-dom-mig 2003
                   :end-yr-avg-dom-mig 2014
                   :start-yr-avg-inter-mig 2003

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -32,19 +32,24 @@
              :proportion-male-newborns (double (/ 105 205))
              :first-proj-year 2014
              :last-proj-year 2015
-             :number-of-years-mort 5
-             :jumpoff-year-mort 2015
-             :number-of-years-mig 12
-             :jumpoff-year-mig 2015})
+             :start-yr-avg-mort 2010 ;; should be >= earliest year in deaths data
+             :end-yr-avg-mort 2014 ;; should be <= mortality jumpoff year-1
+             :start-yr-avg-dom-mig 2003 ;; should be >=earliest year in domestic migrants data
+             :end-yr-avg-dom-mig 2014 ;; should be <= migration jumpoff year-1
+             :start-yr-avg-inter-mig 2003 ;; should be >=earliest year in international migrants data
+             :end-yr-avg-inter-mig 2014 ;; should be <= migration jumpoff year-1
+             })
 
 (def params-2040 {:fert-last-yr 2014
                   :proportion-male-newborns (double (/ 105 205))
                   :first-proj-year 2014
                   :last-proj-year 2040
-                  :number-of-years-mort 5
-                  :jumpoff-year-mort 2015
-                  :number-of-years-mig 12
-                  :jumpoff-year-mig 2015})
+                  :start-yr-avg-mort 2010
+                  :end-yr-avg-mort 2014
+                  :start-yr-avg-dom-mig 2003
+                  :end-yr-avg-dom-mig 2014
+                  :start-yr-avg-inter-mig 2003
+                  :end-yr-avg-inter-mig 2014})
 
 (def prepared-inputs (-> data-inputs
                          prepare-inputs

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -33,7 +33,7 @@
              :last-proj-year 2015
              ;; Fertility module
              :fert-last-yr 2014
-             :start-yr-avg-fert 2013
+             :start-yr-avg-fert 2014
              :end-yr-avg-fert 2014 ;; (s/validate (s/eq :fert-last-yr) :end-yr-avg-fert)
              :proportion-male-newborns (double (/ 105 205))
              ;; Mortality module
@@ -56,7 +56,7 @@
                   :last-proj-year 2040
                   ;; Fertility module
                   :fert-last-yr 2014
-                  :start-yr-avg-fert 2013
+                  :start-yr-avg-fert 2014
                   :end-yr-avg-fert 2014
                   :proportion-male-newborns (double (/ 105 205))
                   ;; Mortality module

--- a/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
+++ b/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
@@ -21,7 +21,10 @@
                            :population-at-risk ;;this actually comes from the proj loop but for test use this csv
                            "test_data/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"}))
 
-(def params {:fert-last-yr 2014 :proportion-male-newborns (double (/ 105 205))})
+(def params {:fert-last-yr 2014
+             :start-yr-avg-fert 2013
+             :end-yr-avg-fert 2014
+             :proportion-male-newborns (double (/ 105 205))})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; R outputs for comparison ;;

--- a/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
+++ b/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
@@ -22,7 +22,7 @@
                            "test_data/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"}))
 
 (def params {:fert-last-yr 2014
-             :start-yr-avg-fert 2013
+             :start-yr-avg-fert 2014
              :end-yr-avg-fert 2014
              :proportion-male-newborns (double (/ 105 205))})
 

--- a/test/witan/models/dem/ccm/mig/net_migration_test.clj
+++ b/test/witan/models/dem/ccm/mig/net_migration_test.clj
@@ -21,7 +21,10 @@
                                       :net-migration
                                       "test_data/r_outputs_for_testing/mig/bristol_migration_module_r_output_2015.csv")))
 
-(def params {:number-of-years-mig 12 :jumpoff-year-mig 2015})
+(def params {:start-yr-avg-dom-mig 2003
+             :end-yr-avg-dom-mig 2014
+             :start-yr-avg-inter-mig 2003
+             :end-yr-avg-inter-mig 2014})
 
 (deftest combine-into-net-flows-test
   (testing "The net migration flows are calculated correctly."

--- a/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
+++ b/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
@@ -33,6 +33,9 @@
                        :deaths
                        (ds/rename-columns {:deaths :deaths-r})))
 
+(def params {:start-yr-avg-mort 2010
+             :end-yr-avg-mort 2014})
+
 (deftest calc-historic-asmr-test
   (testing "Death rates are calculated correctly."
     (let [hist-asmr-r (ds/rename-columns historic-asmr-r {:death-rate :death-rate-r})
@@ -44,9 +47,6 @@
                                (i/sel joined-asmr :rows % :cols :death-rate)
                                0.0000000001)
                   (range (first (:shape joined-asmr))))))))
-
-(def params {:start-yr-avg-mort 2010
-             :end-yr-avg-mort 2014})
 
 (deftest project-asmr-test
   (testing "mortality rates projected correctly"

--- a/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
+++ b/test/witan/models/dem/ccm/mort/mortality_mvp_test.clj
@@ -45,7 +45,8 @@
                                0.0000000001)
                   (range (first (:shape joined-asmr))))))))
 
-(def params {:number-of-years-mort 5 :jumpoff-year-mort 2015})
+(def params {:start-yr-avg-mort 2010
+             :end-yr-avg-mort 2014})
 
 (deftest project-asmr-test
   (testing "mortality rates projected correctly"


### PR DESCRIPTION
Enable start/end years instead of number of years to average over for the mortality and migration modules.

Asked Ben / Wil if adding start/end years specific to each type of migration makes sense.
-> If I understood Ben's reply it can be useful to be able to set different year ranges between domestic and international migrations.

I added a schema validation but not sure it's the way to do it: https://github.com/MastodonC/witan.models.demography/blob/feature/start-end-yr-for-avg-proj/src/witan/models/dem/ccm/components_functions.clj#L18-L19
