### PR TITLE
Fix output path validation.

### DIFF
--- a/default_config.edn
+++ b/default_config.edn
@@ -24,6 +24,7 @@
  {;; Core module
   :first-proj-year 2014
   :last-proj-year 2015
+
   ;; Fertility module
   :fert-last-yr 2014
   :start-yr-avg-fert 2014
@@ -31,12 +32,14 @@
   :number-male-newborns 105
   :number-all-newborns 205
   ;; :proportion-male-newborns (double (/ 105 205)) <- issue when parsing the file
+
   ;; Mortality module
-  :start-yr-avg-mort 2010 ;; Expected > or = to earliest year of mortality data
-  :end-yr-avg-mort 2014 ;; Expected < or = to latest year of mortality data
+  :start-yr-avg-mort 2010 ;; Expected > or = to earliest year of mortality data (2002)
+  :end-yr-avg-mort 2014 ;; Expected < or = to latest year of mortality data (2014)
+
   ;; Migration module
-  :start-yr-avg-dom-mig 2003 ;; Expected > or = to earliest year of domestic migration data
-  :end-yr-avg-dom-mig 2014 ;; Expected < or = to latest year of domestic migration data
-  :start-yr-avg-inter-mig 2003 ;; Expected > or = to earliest year of international migration data
-  :end-yr-avg-inter-mig 2014 ;; Expected < or = to latest year of domestic international data
+  :start-yr-avg-dom-mig 2003 ;; Expected > or = to earliest year of domestic migration data (2002)
+  :end-yr-avg-dom-mig 2014 ;; Expected < or = to latest year of domestic migration data (2014)
+  :start-yr-avg-inter-mig 2003 ;; Expected > or = to earliest year of international migration data (2002)
+  :end-yr-avg-inter-mig 2014 ;; Expected < or = to latest year of domestic international data (2014)
   }}

--- a/src/witan/models/run_models.clj
+++ b/src/witan/models/run_models.clj
@@ -136,7 +136,7 @@
     :validate [#(.exists (jio/file %)) "Must be an existing file path"]
     :default "./default_config.edn"]
    ["-o" "--output-projections FILEPATH" "Filepath for the output projections"
-    :validate [#(.exists (jio/as-file (.getPath (jio/file %))))
+    :validate [#(.exists (jio/as-file (.getParent (jio/file %))))
                "Must contain an existing path of directories"]
     :default "./ccm_projections.csv"]
    ["-c" "--gss-code for a English local authority" "Gss code for the local authority of interest"]])


### PR DESCRIPTION
The command-line options contain validations for the input (`-i`) and the output (`-o`).
For the output the validation used to always return false bc it was checking if the file exists instead of checking if the path of directories exists.
Changing `getPath` to `getParent` seem to have fixed this.

I also included in this PR tiny changes to the config file to make it more readable.
