### PR TITLE
Add extra migration flows parameters.

### DIFF
--- a/default_config.edn
+++ b/default_config.edn
@@ -38,8 +38,12 @@
   :end-yr-avg-mort 2014 ;; Expected < or = to latest year of mortality data (2014)
 
   ;; Migration module
-  :start-yr-avg-dom-mig 2003 ;; Expected > or = to earliest year of domestic migration data (2002)
-  :end-yr-avg-dom-mig 2014 ;; Expected < or = to latest year of domestic migration data (2014)
-  :start-yr-avg-inter-mig 2003 ;; Expected > or = to earliest year of international migration data (2002)
-  :end-yr-avg-inter-mig 2014 ;; Expected < or = to latest year of domestic international data (2014)
+  :start-yr-avg-domin-mig 2003 ;; Expected > or = to earliest year of domestic in-migration data (2002)
+  :end-yr-avg-domin-mig 2014 ;; Expected < or = to latest year of domestic in-migration data (2014)
+  :start-yr-avg-domout-mig 2003 ;; Expected > or = to earliest year of domestic out-migration data (2002)
+  :end-yr-avg-domout-mig 2014 ;; Expected < or = to latest year of domestic out-migration data (2014)
+  :start-yr-avg-intin-mig 2003 ;; Expected > or = to earliest year of international in-migration data (2002)
+  :end-yr-avg-intin-mig 2014 ;; Expected < or = to latest year of domestic international in-migration data (2014)
+  :start-yr-avg-intout-mig 2003 ;; Expected > or = to earliest year of international out-migration data (2002)
+  :end-yr-avg-intout-mig 2014 ;; Expected < or = to latest year of domestic international out-migration data (2014)
   }}

--- a/src-cli/witan/models/run_models.clj
+++ b/src-cli/witan/models/run_models.clj
@@ -142,12 +142,12 @@
    :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
    :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-deaths-from-fixed-rates}
    :proj-dom-in-migrants  {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
-                                :params {:start-yr-avg-dom-mig (:start-yr-avg-dom-mig params)
-                                         :end-yr-avg-dom-mig (:end-yr-avg-dom-mig params)}}
+                                :params {:start-yr-avg-domin-mig (:start-yr-avg-domin-mig params)
+                                         :end-yr-avg-domin-mig (:end-yr-avg-domin-mig params)}}
    :calc-hist-asmr         {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
    :proj-dom-out-migrants {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
-                                :params {:start-yr-avg-dom-mig (:start-yr-avg-dom-mig params)
-                                         :end-yr-avg-dom-mig (:end-yr-avg-dom-mig params)}}
+                                :params {:start-yr-avg-domout-mig (:start-yr-avg-domout-mig params)
+                                         :end-yr-avg-domout-mig (:end-yr-avg-domout-mig params)}}
    :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
    :age-on                     {:var #'witan.models.dem.ccm.core.projection-loop/age-on}
    :project-births             {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-births-from-fixed-rates}
@@ -163,11 +163,11 @@
                                 :params {:fert-last-yr (:fert-last-yr params)}}
    :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
    :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-international-in-migrants
-                                :params {:start-yr-avg-inter-mig (:start-yr-avg-inter-mig params)
-                                         :end-yr-avg-inter-mig (:end-yr-avg-inter-mig params)}}
+                                :params {:start-yr-avg-intin-mig (:start-yr-avg-intin-mig params)
+                                         :end-yr-avg-intin-mig (:end-yr-avg-intin-mig params)}}
    :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.net-migration/project-international-out-migrants
-                                :params {:start-yr-avg-inter-mig (:start-yr-avg-inter-mig params)
-                                         :end-yr-avg-inter-mig (:end-yr-avg-inter-mig params)}}
+                                :params {:start-yr-avg-intout-mig (:start-yr-avg-intout-mig params)
+                                         :end-yr-avg-intout-mig (:end-yr-avg-intout-mig params)}}
 
    :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.net-migration/combine-into-net-flows}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/witan/models/dem/ccm/mig/net_migration.clj
+++ b/src/witan/models/dem/ccm/mig/net_migration.clj
@@ -10,49 +10,49 @@
   {:witan/name :ccm-mig/proj-dom-in-mig
    :witan/version "1.0"
    :witan/input-schema {:domestic-in-migrants ComponentMYESchema}
-   :witan/param-schema {:start-yr-avg-dom-mig s/Int :end-yr-avg-dom-mig s/Int}
+   :witan/param-schema {:start-yr-avg-domin-mig s/Int :end-yr-avg-domin-mig s/Int}
    :witan/output-schema {:projected-domestic-in-migrants ProjDomInSchema}
    :witan/exported? true}
-  [{:keys [domestic-in-migrants]} {:keys [start-yr-avg-dom-mig end-yr-avg-dom-mig]}]
+  [{:keys [domestic-in-migrants]} {:keys [start-yr-avg-domin-mig end-yr-avg-domin-mig]}]
   {:projected-domestic-in-migrants
    (cf/jumpoffyr-method-average domestic-in-migrants :estimate
-                                :domestic-in start-yr-avg-dom-mig end-yr-avg-dom-mig)})
+                                :domestic-in start-yr-avg-domin-mig end-yr-avg-domin-mig)})
 
 (defworkflowfn project-domestic-out-migrants
   {:witan/name :ccm-mig/proj-dom-out-mig
    :witan/version "1.0"
    :witan/input-schema {:domestic-out-migrants ComponentMYESchema}
-   :witan/param-schema {:start-yr-avg-dom-mig s/Int :end-yr-avg-dom-mig s/Int}
+   :witan/param-schema {:start-yr-avg-domout-mig s/Int :end-yr-avg-domout-mig s/Int}
    :witan/output-schema {:projected-domestic-out-migrants ProjDomOutSchema}
    :witan/exported? true}
-  [{:keys [domestic-out-migrants]} {:keys [start-yr-avg-dom-mig end-yr-avg-dom-mig]}]
+  [{:keys [domestic-out-migrants]} {:keys [start-yr-avg-domout-mig end-yr-avg-domout-mig]}]
   {:projected-domestic-out-migrants
    (cf/jumpoffyr-method-average domestic-out-migrants :estimate
-                                :domestic-out start-yr-avg-dom-mig end-yr-avg-dom-mig)})
+                                :domestic-out start-yr-avg-domout-mig end-yr-avg-domout-mig)})
 
 (defworkflowfn project-international-in-migrants
   {:witan/name :ccm-mig/proj-inter-in-mig
    :witan/version "1.0"
    :witan/input-schema {:international-in-migrants ComponentMYESchema}
-   :witan/param-schema {:start-yr-avg-inter-mig s/Int :end-yr-avg-inter-mig s/Int}
+   :witan/param-schema {:start-yr-avg-intin-mig s/Int :end-yr-avg-intin-mig s/Int}
    :witan/output-schema {:projected-international-in-migrants ProjInterInSchema}
    :witan/exported? true}
-  [{:keys [international-in-migrants]} {:keys [start-yr-avg-inter-mig end-yr-avg-inter-mig]}]
+  [{:keys [international-in-migrants]} {:keys [start-yr-avg-intin-mig end-yr-avg-intin-mig]}]
   {:projected-international-in-migrants
    (cf/jumpoffyr-method-average international-in-migrants :estimate
-                                :international-in start-yr-avg-inter-mig end-yr-avg-inter-mig)})
+                                :international-in start-yr-avg-intin-mig end-yr-avg-intin-mig)})
 
 (defworkflowfn project-international-out-migrants
   {:witan/name :ccm-mig/proj-inter-out-mig
    :witan/version "1.0"
    :witan/input-schema {:international-out-migrants ComponentMYESchema}
-   :witan/param-schema {:start-yr-avg-inter-mig s/Int :end-yr-avg-inter-mig s/Int}
+   :witan/param-schema {:start-yr-avg-intout-mig s/Int :end-yr-avg-intout-mig s/Int}
    :witan/output-schema {:projected-international-out-migrants ProjInterOutSchema}
    :witan/exported? true}
-  [{:keys [international-out-migrants]} {:keys [start-yr-avg-inter-mig end-yr-avg-inter-mig]}]
+  [{:keys [international-out-migrants]} {:keys [start-yr-avg-intout-mig end-yr-avg-intout-mig]}]
   {:projected-international-out-migrants
    (cf/jumpoffyr-method-average international-out-migrants :estimate
-                                :international-out start-yr-avg-inter-mig end-yr-avg-inter-mig)})
+                                :international-out start-yr-avg-intout-mig end-yr-avg-intout-mig)})
 
 (defworkflowfn combine-into-net-flows
   {:witan/name :ccm-mig/combine-mig-flows

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -25,12 +25,12 @@
    :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
    :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-deaths-from-fixed-rates}
    :proj-dom-in-migrants  {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
-                                :params {:start-yr-avg-dom-mig 2003
-                                         :end-yr-avg-dom-mig 2014}}
+                                :params {:start-yr-avg-domin-mig 2003
+                                         :end-yr-avg-domin-mig 2014}}
    :calc-hist-asmr         {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
    :proj-dom-out-migrants {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
-                                :params {:start-yr-avg-dom-mig 2003
-                                         :end-yr-avg-dom-mig 2014}}
+                                :params {:start-yr-avg-domout-mig 2003
+                                         :end-yr-avg-domout-mig 2014}}
    :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
    :age-on                     {:var #'witan.models.dem.ccm.core.projection-loop/age-on}
    :project-births             {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-births-from-fixed-rates}
@@ -45,11 +45,11 @@
                                 :params {:fert-last-yr 2014}}
    :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
    :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-international-in-migrants
-                                :params {:start-yr-avg-inter-mig 2003
-                                         :end-yr-avg-inter-mig 2014}}
+                                :params {:start-yr-avg-intin-mig 2003
+                                         :end-yr-avg-intin-mig 2014}}
    :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.net-migration/project-international-out-migrants
-                                :params {:start-yr-avg-inter-mig 2003
-                                         :end-yr-avg-inter-mig 2014}}
+                                :params {:start-yr-avg-intout-mig 2003
+                                         :end-yr-avg-intout-mig 2014}}
 
    :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.net-migration/combine-into-net-flows}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -42,14 +42,22 @@
              ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mort))) :end-yr-avg-mort)
              :end-yr-avg-mort 2014
              ;; Migration module
-             ;; (s/validate (s/pred (>= % earliest-dom-mig-yr)) :start-yr-avg-dom-mig)
-             :start-yr-avg-dom-mig 2003
-             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-dom-mig)
-             :end-yr-avg-dom-mig 2014
-             ;; (s/validate (s/pred (>= % earliest-inter-mig-yr)) :start-yr-avg-inter-mig)
-             :start-yr-avg-inter-mig 2003
-             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-inter-mig)
-             :end-yr-avg-inter-mig 2014})
+             ;; (s/validate (s/pred (>= % earliest-domin-mig-yr)) :start-yr-avg-domin-mig)
+             :start-yr-avg-domin-mig 2003
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-domin-mig)
+             :end-yr-avg-domin-mig 2014
+             ;; (s/validate (s/pred (>= % earliest-domout-mig-yr)) :start-yr-avg-domout-mig)
+             :start-yr-avg-domout-mig 2003
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-domout-mig)
+             :end-yr-avg-domout-mig 2014
+             ;; (s/validate (s/pred (>= % earliest-intin-mig-yr)) :start-yr-avg-intin-mig)
+             :start-yr-avg-intin-mig 2003
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-intin-mig)
+             :end-yr-avg-intin-mig 2014
+             ;; (s/validate (s/pred (>= % earliest-intout-mig-yr)) :start-yr-avg-intout-mig)
+             :start-yr-avg-intout-mig 2003
+             ;; (s/validate (s/pred (<= % (dec jumpoff-yr-mig))) :end-yr-avg-intout-mig)
+             :end-yr-avg-intout-mig 2014})
 
 (def params-2040 {;; Core module
                   :first-proj-year 2014
@@ -63,10 +71,14 @@
                   :start-yr-avg-mort 2010
                   :end-yr-avg-mort 2014
                   ;; Migration module
-                  :start-yr-avg-dom-mig 2003
-                  :end-yr-avg-dom-mig 2014
-                  :start-yr-avg-inter-mig 2003
-                  :end-yr-avg-inter-mig 2014})
+                  :start-yr-avg-domin-mig 2003
+                  :end-yr-avg-domin-mig 2014
+                  :start-yr-avg-domout-mig 2003
+                  :end-yr-avg-domout-mig 2014
+                  :start-yr-avg-intin-mig 2003
+                  :end-yr-avg-intin-mig 2014
+                  :start-yr-avg-intout-mig 2003
+                  :end-yr-avg-intout-mig 2014})
 
 (def prepared-inputs (prepare-inputs data-inputs))
 

--- a/test/witan/models/dem/ccm/mig/net_migration_test.clj
+++ b/test/witan/models/dem/ccm/mig/net_migration_test.clj
@@ -22,10 +22,14 @@
                                       :net-migration
                                       "./datasets/test_datasets/r_outputs_for_testing/mig/bristol_migration_module_r_output_2015.csv")))
 
-(def params {:start-yr-avg-dom-mig 2003
-             :end-yr-avg-dom-mig 2014
-             :start-yr-avg-inter-mig 2003
-             :end-yr-avg-inter-mig 2014})
+(def params {:start-yr-avg-domin-mig 2003
+             :end-yr-avg-domin-mig 2014
+             :start-yr-avg-domout-mig 2003
+             :end-yr-avg-domout-mig 2014
+             :start-yr-avg-intin-mig 2003
+             :end-yr-avg-intin-mig 2014
+             :start-yr-avg-intout-mig 2003
+             :end-yr-avg-intout-mig 2014})
 
 (deftest combine-into-net-flows-test
   (testing "The net migration flows are calculated correctly."


### PR DESCRIPTION
There are now four pairs of start/end years to average on for migration flows projection

-> changes in `default_config.edn` that had to be implemented all over the project
