### PR TITLE
Add a popn-at-risk schema.

### DIFF
--- a/datasets/test_datasets/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv
+++ b/datasets/test_datasets/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv
@@ -1,4 +1,4 @@
-GSS.Code,Sex,Age,Year,Popn
+GSS.Code,Sex,Age,Year,Popn-at-risk
 E06000023,F,0,2015,3130
 E06000023,M,0,2015,3195
 E06000023,F,1,2015,3079

--- a/src/witan/models/dem/ccm/components_functions.clj
+++ b/src/witan/models/dem/ccm/components_functions.clj
@@ -63,7 +63,7 @@
   [population-at-risk fixed-rates col-fixed-rates col-result]
   (-> fixed-rates
       (wds/join population-at-risk [:gss-code :age :sex])
-      (wds/add-derived-column col-result [col-fixed-rates :popn] *)
+      (wds/add-derived-column col-result [col-fixed-rates :popn-at-risk] *)
       (ds/select-columns [:gss-code :sex :age :year col-result])))
 
 (defn order-ds

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -53,12 +53,12 @@
    :witan/input-schema {:latest-yr-popn HistPopulationSchema
                         :loop-year s/Int}
    :witan/output-schema {:latest-yr-popn HistPopulationSchema :loop-year s/Int
-                         :population-at-risk HistPopulationSchema}
+                         :population-at-risk PopulationAtRiskSchema}
    :witan/exported? true}
   [{:keys [latest-yr-popn loop-year]} _]
   (let [update-yr (ds/emap-column latest-yr-popn :year inc)]
     {:latest-yr-popn update-yr :loop-year (inc loop-year)
-     :population-at-risk update-yr}))
+     :population-at-risk (ds/rename-columns update-yr {:popn :popn-at-risk})}))
 
 (defworkflowfn age-on
   "Takes in a dataset with the starting-population.

--- a/src/witan/models/dem/ccm/schemas.clj
+++ b/src/witan/models/dem/ccm/schemas.clj
@@ -80,11 +80,16 @@
 (def InterOutAverageSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:intout double]]))
 
-;; For the mortality component
+;; For the core module
 (def HistPopulationSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:popn double]]))
 
+(def PopulationAtRiskSchema
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
+                           [:year s/Int] [:popn-at-risk double]]))
+
+;; For the mortality component
 (def HistASMRSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:death-rate double]]))
@@ -93,7 +98,6 @@
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:death-rate double]]))
 
 ;; For the fertility component
-
 (def HistASFRSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:fert-rate double]]))

--- a/src/witan/models/load_data.clj
+++ b/src/witan/models/load_data.clj
@@ -139,8 +139,8 @@
 
 (defmethod apply-record-coercion :population-at-risk
   [data-info csv-data]
-  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
-   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
+  {:column-names (apply-col-names-schema PopulationAtRiskSchema csv-data)
+   :columns (vec (apply-row-schema PopulationAtRiskSchema csv-data))})
 
 (defmethod apply-record-coercion :historic-asmr
   [data-info csv-data]


### PR DESCRIPTION
- Add a popn at risk schema w/ `:popn` column changed to `:popn-at-risk` for the population at risk created in the "core module".
- Change `:popn` column to `:popn-at-risk` in the populations at risk created in the fertility and mortality modules.
- Implement all changes in column names.
