### PR TITLE
Tidy up MVP fertility fns

### DIFF
--- a/default_config.edn
+++ b/default_config.edn
@@ -26,9 +26,7 @@
   :last-proj-year 2015
 
   ;; Fertility module
-  :fert-last-yr 2014
-  :start-yr-avg-fert 2014
-  :end-yr-avg-fert 2014 ;; Expected = to :fert-last-yr
+  :fert-base-yr 2014
   ;; proportion of male newborns in the UK -> 105/205
   :number-male-newborns 105 ;; <- keep that value for a population projection for the UK
   :number-all-newborns 205 ;; <- keep that value for a population projection for the UK

--- a/src-cli/witan/models/run_models.clj
+++ b/src-cli/witan/models/run_models.clj
@@ -134,18 +134,16 @@
 (defn tasks [inputs params gss-code]
   { ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Functions
-   :project-asfr         {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-asfr-finalyrhist-fixed
-                                :params {:fert-last-yr (:fert-last-yr params)
-                                         :start-yr-avg-fert (:start-yr-avg-fert params)
-                                         :end-yr-avg-fert (:end-yr-avg-fert params)}}
+   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-asfr-finalyrhist-fixed
+                                :params {:fert-base-yr (:fert-base-yr params)}}
    :join-popn-latest-yr        {:var #'witan.models.dem.ccm.core.projection-loop/join-popn-latest-yr}
    :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
    :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-deaths-from-fixed-rates}
-   :proj-dom-in-migrants  {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
+   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
                                 :params {:start-yr-avg-domin-mig (:start-yr-avg-domin-mig params)
                                          :end-yr-avg-domin-mig (:end-yr-avg-domin-mig params)}}
-   :calc-hist-asmr         {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
-   :proj-dom-out-migrants {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
+   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
+   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
                                 :params {:start-yr-avg-domout-mig (:start-yr-avg-domout-mig params)
                                          :end-yr-avg-domout-mig (:end-yr-avg-domout-mig params)}}
    :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
@@ -154,13 +152,13 @@
    :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility-mvp/combine-into-births-by-sex
                                 :params {:proportion-male-newborns
                                          (:proportion-male-newborns params)}}
-   :project-asmr         {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-asmr
+   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-asmr
                                 :params {:start-yr-avg-mort (:start-yr-avg-mort params)
                                          :end-yr-avg-mort (:end-yr-avg-mort params)}}
    :select-starting-popn       {:var #'witan.models.dem.ccm.core.projection-loop/select-starting-popn}
    :prepare-starting-popn      {:var #'witan.models.dem.ccm.core.projection-loop/prepare-inputs}
-   :calc-hist-asfr         {:var #'witan.models.dem.ccm.fert.fertility-mvp/calculate-historic-asfr
-                                :params {:fert-last-yr (:fert-last-yr params)}}
+   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility-mvp/calculate-historic-asfr
+                                :params {:fert-base-yr (:fert-base-yr params)}}
    :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
    :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-international-in-migrants
                                 :params {:start-yr-avg-intin-mig (:start-yr-avg-intin-mig params)
@@ -178,37 +176,37 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Inputs
    :in-hist-popn                  {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:historic-population inputs)
-                                        :key :historic-population}}
+                                   :params {:gss-code gss-code
+                                            :src (:historic-population inputs)
+                                            :key :historic-population}}
    :in-hist-total-births          {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:historic-births inputs)
-                                                :key :historic-births}}
+                                   :params {:gss-code gss-code
+                                            :src (:historic-births inputs)
+                                            :key :historic-births}}
    :in-proj-births-by-age-of-mother  {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:ons-proj-births-by-age-mother inputs)
-                                                :key :ons-proj-births-by-age-mother}}
+                                      :params {:gss-code gss-code
+                                               :src (:ons-proj-births-by-age-mother inputs)
+                                               :key :ons-proj-births-by-age-mother}}
    :in-hist-deaths-by-age-and-sex {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:historic-deaths inputs)
-                                                :key :historic-deaths}}
+                                   :params {:gss-code gss-code
+                                            :src (:historic-deaths inputs)
+                                            :key :historic-deaths}}
    :in-hist-dom-in-migrants       {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:domestic-in-migrants inputs)
-                                                :key :domestic-in-migrants}}
+                                   :params {:gss-code gss-code
+                                            :src (:domestic-in-migrants inputs)
+                                            :key :domestic-in-migrants}}
    :in-hist-dom-out-migrants      {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:domestic-out-migrants inputs)
-                                                :key :domestic-out-migrants}}
+                                   :params {:gss-code gss-code
+                                            :src (:domestic-out-migrants inputs)
+                                            :key :domestic-out-migrants}}
    :in-hist-intl-in-migrants      {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:international-in-migrants inputs)
-                                                :key :international-in-migrants}}
+                                   :params {:gss-code gss-code
+                                            :src (:international-in-migrants inputs)
+                                            :key :international-in-migrants}}
    :in-hist-intl-out-migrants     {:var #'witan.models.run-models/resource-csv-loader-filtered
-                                       :params {:gss-code gss-code
-                                                :src (:international-out-migrants inputs)
-                                                :key :international-out-migrants}}
+                                   :params {:gss-code gss-code
+                                            :src (:international-out-migrants inputs)
+                                            :key :international-out-migrants}}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Outputs
    :out {:var #'witan.models.dem.ccm.models-utils/out}

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -15,20 +15,17 @@
 
 
 (def tasks
-  {;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  { ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Functions
-   :project-asfr         {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-asfr-finalyrhist-fixed
-                                :params {:fert-last-yr 2014
-                                         :start-yr-avg-fert 2014
-                                         :end-yr-avg-fert 2014}}
+   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-asfr-finalyrhist-fixed}
    :join-popn-latest-yr        {:var #'witan.models.dem.ccm.core.projection-loop/join-popn-latest-yr}
    :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
    :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-deaths-from-fixed-rates}
-   :proj-dom-in-migrants  {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
+   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
                                 :params {:start-yr-avg-domin-mig 2003
                                          :end-yr-avg-domin-mig 2014}}
-   :calc-hist-asmr         {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
-   :proj-dom-out-migrants {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
+   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
+   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
                                 :params {:start-yr-avg-domout-mig 2003
                                          :end-yr-avg-domout-mig 2014}}
    :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
@@ -36,13 +33,13 @@
    :project-births             {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-births-from-fixed-rates}
    :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility-mvp/combine-into-births-by-sex
                                 :params {:proportion-male-newborns (double (/ 105 205))}}
-   :project-asmr         {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-asmr
+   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-asmr
                                 :params {:start-yr-avg-mort 2010
                                          :end-yr-avg-mort 2014}}
    :select-starting-popn       {:var #'witan.models.dem.ccm.core.projection-loop/select-starting-popn}
    :prepare-starting-popn      {:var #'witan.models.dem.ccm.core.projection-loop/prepare-inputs}
-   :calc-hist-asfr         {:var #'witan.models.dem.ccm.fert.fertility-mvp/calculate-historic-asfr
-                                :params {:fert-last-yr 2014}}
+   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility-mvp/calculate-historic-asfr
+                                :params {:fert-base-yr 2014}}
    :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
    :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-international-in-migrants
                                 :params {:start-yr-avg-intin-mig 2003
@@ -52,38 +49,38 @@
                                          :end-yr-avg-intout-mig 2014}}
 
    :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.net-migration/combine-into-net-flows}
-   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Predicates
    :finish-looping?            {:var #'witan.models.dem.ccm.core.projection-loop/finished-looping?
                                 :params {:last-proj-year 2021}
                                 :pred? true}
-   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Inputs
    :in-hist-popn                  {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/bristol_hist_popn_mye.csv"
-                                                :key :historic-population}}
+                                   :params {:src "./datasets/test_datasets/model_inputs/bristol_hist_popn_mye.csv"
+                                            :key :historic-population}}
    :in-hist-total-births          {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_hist_births_mye.csv"
-                                                :key :historic-births}}
+                                   :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_hist_births_mye.csv"
+                                            :key :historic-births}}
    :in-proj-births-by-age-of-mother  {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
-                                                :key :ons-proj-births-by-age-mother}}
+                                      :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
+                                               :key :ons-proj-births-by-age-mother}}
    :in-hist-deaths-by-age-and-sex {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/mort/bristol_hist_deaths_mye.csv"
-                                                :key :historic-deaths}}
+                                   :params {:src "./datasets/test_datasets/model_inputs/mort/bristol_hist_deaths_mye.csv"
+                                            :key :historic-deaths}}
    :in-hist-dom-in-migrants       {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_inmigrants.csv"
-                                                :key :domestic-in-migrants}}
+                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_inmigrants.csv"
+                                            :key :domestic-in-migrants}}
    :in-hist-dom-out-migrants      {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_outmigrants.csv"
-                                                :key :domestic-out-migrants}}
+                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_outmigrants.csv"
+                                            :key :domestic-out-migrants}}
    :in-hist-intl-in-migrants      {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_inmigrants.csv"
-                                                :key :international-in-migrants}}
+                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_inmigrants.csv"
+                                            :key :international-in-migrants}}
    :in-hist-intl-out-migrants     {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
-                                       :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_outmigrants.csv"
-                                                :key :international-out-migrants}}
-   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_outmigrants.csv"
+                                            :key :international-out-migrants}}
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Outputs
    :out {:var #'witan.models.dem.ccm.models-utils/out}
    })

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -32,9 +32,7 @@
              :first-proj-year 2014
              :last-proj-year 2015
              ;; Fertility module
-             :fert-last-yr 2014
-             :start-yr-avg-fert 2014
-             :end-yr-avg-fert 2014 ;; (s/validate (s/eq :fert-last-yr) :end-yr-avg-fert)
+             :fert-base-yr 2014
              :proportion-male-newborns (double (/ 105 205))
              ;; Mortality module
              ;; (s/validate (s/pred (>= % earliest-mort-yr)) :start-yr-avg-mort)
@@ -63,9 +61,7 @@
                   :first-proj-year 2014
                   :last-proj-year 2040
                   ;; Fertility module
-                  :fert-last-yr 2014
-                  :start-yr-avg-fert 2014
-                  :end-yr-avg-fert 2014
+                  :fert-base-yr 2014
                   :proportion-male-newborns (double (/ 105 205))
                   ;; Mortality module
                   :start-yr-avg-mort 2010
@@ -85,7 +81,7 @@
 (defn fertility-module [inputs params]
   (-> inputs
       (fert/calculate-historic-asfr params)
-      (fert/project-asfr-finalyrhist-fixed params)
+      fert/project-asfr-finalyrhist-fixed
       fert/project-births-from-fixed-rates
       (fert/combine-into-births-by-sex params)))
 

--- a/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
+++ b/test/witan/models/dem/ccm/fert/fertility_mvp_test.clj
@@ -22,9 +22,7 @@
                         :population-at-risk ;;this actually comes from the proj loop but for test use this csv
                         "./datasets/test_datasets/r_outputs_for_testing/core/bristol_popn_at_risk_2015.csv"}))
 
-(def params {:fert-last-yr 2014
-             :start-yr-avg-fert 2014
-             :end-yr-avg-fert 2014
+(def params {:fert-base-yr 2014
              :proportion-male-newborns (double (/ 105 205))})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -62,7 +60,7 @@
                           (ds/rename-columns {:fert-rate :fert-rate-r}))
           joined-asfr (-> fertility-inputs
                           (calculate-historic-asfr params)
-                          (project-asfr-finalyrhist-fixed params)
+                          project-asfr-finalyrhist-fixed
                           :initial-projected-fertility-rates
                           (wds/join proj-asfr-r [:gss-code :sex :age]))]
       (is (every? #(fp-equals? (i/sel joined-asfr :rows % :cols :fert-rate-r)
@@ -77,7 +75,7 @@
                             (ds/rename-columns {:births :births-r}))
           joined-births (-> fertility-inputs
                             (calculate-historic-asfr params)
-                            (project-asfr-finalyrhist-fixed params)
+                            project-asfr-finalyrhist-fixed
                             project-births-from-fixed-rates
                             :births-by-age-sex-mother
                             (wds/join proj-births-r [:gss-code :sex :age :year]))]
@@ -93,7 +91,7 @@
                               (ds/rename-columns {:births :births-r}))
           joined-births-by-sex (-> fertility-inputs
                                    (calculate-historic-asfr params)
-                                   (project-asfr-finalyrhist-fixed params)
+                                   project-asfr-finalyrhist-fixed
                                    project-births-from-fixed-rates
                                    (combine-into-births-by-sex params)
                                    :births


### PR DESCRIPTION
- remove 2 fertility parameters unnecessary for the MVP CCM
- remove parameters completely from the project-asfr-finalyrhist-fixed fn
- rewrite project-asfr-finalyrhist-fixed fn
- rename the 1 remaining parameter for the historic fertility calculations from fert-last-yr to fert-base-yr. The reason for this is clarity - the user chooses which year will be the base year of fertility rate projections, where base year = the year before starting projections. Base year is familiar terminology to demographers such as Piers Elias and our GLA colleagues.
