### PR TITLE
Rename the :historical-population

### DIFF
--- a/src-cli/witan/models/run_models.clj
+++ b/src-cli/witan/models/run_models.clj
@@ -220,7 +220,7 @@
                        :contracts (make-contracts tasks)}
         workspace'    (s/with-fn-validation (wex/build! workspace))
         result        (wex/run!! workspace' {})]
-    (:historic-population (first result))))
+    (:population (first result))))
 
 (def cli-options
   [["-i" "--input-config FILEPATH" "Filepath for the config file with inputs info"

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -31,10 +31,10 @@
 
 (defworkflowfn prepare-inputs
   "Step happening before the projection loop.
-   Takes in the historic population and outputs
-   the latest year and the population for that year.
-   Both those elements will be updated within the
-   projection loop."
+   Takes in the historic population and outputs the latest year and
+   the population for that year which will be updated within the
+   projection loop. Also outputs the the population that will ultimately
+   contain the historic population and the population projections."
   {:witan/name :ccm-core/prepare-starting-popn
    :witan/version "1.0"
    :witan/input-schema {:historic-population PopulationSchema}
@@ -134,7 +134,7 @@
     {:latest-yr-popn popn-w-migrants}))
 
 (defworkflowfn join-popn-latest-yr
-  "Takes in a dataset of popn for previous years and a dataset of
+  "Takes in a dataset of population for previous years and a dataset of
    projected population for the next year of projection.
    Returns a datasets that appends the second dataset to the first one."
   {:witan/name :ccm-core/join-yrs

--- a/src/witan/models/dem/ccm/fert/fertility_mvp.clj
+++ b/src/witan/models/dem/ccm/fert/fertility_mvp.clj
@@ -78,7 +78,7 @@
   {:witan/name :ccm-fert/calc-hist-asfr
    :witan/version "1.0"
    :witan/input-schema {:ons-proj-births-by-age-mother BirthsAgeSexMotherSchema
-                        :historic-population HistPopulationSchema
+                        :historic-population PopulationSchema
                         :historic-births BirthsSchema}
    :witan/param-schema {:fert-base-yr s/Int}
    :witan/output-schema {:historic-asfr HistASFRSchema}

--- a/src/witan/models/dem/ccm/mort/mortality_mvp.clj
+++ b/src/witan/models/dem/ccm/mort/mortality_mvp.clj
@@ -45,7 +45,7 @@
    :witan/version "1.0"
    :witan/input-schema {:historic-deaths DeathsSchema
                         :historic-births BirthsSchema
-                        :historic-population HistPopulationSchema}
+                        :historic-population PopulationSchema}
    :witan/output-schema {:historic-asmr HistASMRSchema}
    :witan/exported? true}
   [{:keys [historic-deaths historic-births historic-population]} _]

--- a/src/witan/models/dem/ccm/schemas.clj
+++ b/src/witan/models/dem/ccm/schemas.clj
@@ -92,7 +92,7 @@
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:intout double]]))
 
 ;; For the core module
-(def HistPopulationSchema
+(def PopulationSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
                            [:year s/Int] [:popn double]]))
 

--- a/src/witan/models/load_data.clj
+++ b/src/witan/models/load_data.clj
@@ -59,13 +59,13 @@
 
 (defmethod apply-record-coercion :historic-population
   [data-info csv-data]
-  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
-   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
+  {:column-names (apply-col-names-schema PopulationSchema csv-data)
+   :columns (vec (apply-row-schema PopulationSchema csv-data))})
 
 (defmethod apply-record-coercion :end-population
   [data-info csv-data]
-  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
-   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
+  {:column-names (apply-col-names-schema PopulationSchema csv-data)
+   :columns (vec (apply-row-schema PopulationSchema csv-data))})
 
 (defmethod apply-record-coercion :births
   [data-info csv-data]
@@ -134,8 +134,8 @@
 
 (defmethod apply-record-coercion :historic-population
   [data-info csv-data]
-  {:column-names (apply-col-names-schema HistPopulationSchema csv-data)
-   :columns (vec (apply-row-schema HistPopulationSchema csv-data))})
+  {:column-names (apply-col-names-schema PopulationSchema csv-data)
+   :columns (vec (apply-row-schema PopulationSchema csv-data))})
 
 (defmethod apply-record-coercion :population-at-risk
   [data-info csv-data]

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -115,6 +115,7 @@
                              :projected-international-out-migrants
                              :population-at-risk
                              :historic-population
+                             :population
                              :international-out-migrants])]
     (is result)
     (is (= expected-keys (-> result first keys vec sort)))


### PR DESCRIPTION
Within the loop, added a new output key `:population` for a dataset that contains both historical data and projections. It is now separated from the `:historic-population`.
