### PR TITLE
rename namespaces

### DIFF
--- a/src-cli/witan/models/run_models.clj
+++ b/src-cli/witan/models/run_models.clj
@@ -134,40 +134,40 @@
 (defn tasks [inputs params gss-code]
   { ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Functions
-   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-asfr-finalyrhist-fixed
+   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility/project-asfr-finalyrhist-fixed
                                 :params {:fert-base-yr (:fert-base-yr params)}}
    :join-popn-latest-yr        {:var #'witan.models.dem.ccm.core.projection-loop/join-popn-latest-yr}
    :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
-   :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-deaths-from-fixed-rates}
-   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
+   :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality/project-deaths-from-fixed-rates}
+   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.migration/project-domestic-in-migrants
                                 :params {:start-yr-avg-domin-mig (:start-yr-avg-domin-mig params)
                                          :end-yr-avg-domin-mig (:end-yr-avg-domin-mig params)}}
-   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
-   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
+   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality/calc-historic-asmr}
+   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.migration/project-domestic-out-migrants
                                 :params {:start-yr-avg-domout-mig (:start-yr-avg-domout-mig params)
                                          :end-yr-avg-domout-mig (:end-yr-avg-domout-mig params)}}
    :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
    :age-on                     {:var #'witan.models.dem.ccm.core.projection-loop/age-on}
-   :project-births             {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-births-from-fixed-rates}
-   :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility-mvp/combine-into-births-by-sex
+   :project-births             {:var #'witan.models.dem.ccm.fert.fertility/project-births-from-fixed-rates}
+   :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility/combine-into-births-by-sex
                                 :params {:proportion-male-newborns
                                          (:proportion-male-newborns params)}}
-   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-asmr
+   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality/project-asmr
                                 :params {:start-yr-avg-mort (:start-yr-avg-mort params)
                                          :end-yr-avg-mort (:end-yr-avg-mort params)}}
    :select-starting-popn       {:var #'witan.models.dem.ccm.core.projection-loop/select-starting-popn}
    :prepare-starting-popn      {:var #'witan.models.dem.ccm.core.projection-loop/prepare-inputs}
-   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility-mvp/calculate-historic-asfr
+   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility/calculate-historic-asfr
                                 :params {:fert-base-yr (:fert-base-yr params)}}
    :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
-   :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-international-in-migrants
+   :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.migration/project-international-in-migrants
                                 :params {:start-yr-avg-intin-mig (:start-yr-avg-intin-mig params)
                                          :end-yr-avg-intin-mig (:end-yr-avg-intin-mig params)}}
-   :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.net-migration/project-international-out-migrants
+   :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.migration/project-international-out-migrants
                                 :params {:start-yr-avg-intout-mig (:start-yr-avg-intout-mig params)
                                          :end-yr-avg-intout-mig (:end-yr-avg-intout-mig params)}}
 
-   :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.net-migration/combine-into-net-flows}
+   :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.migration/combine-into-net-flows}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Predicates
    :finish-looping?            {:var #'witan.models.dem.ccm.core.projection-loop/finished-looping?

--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -5,9 +5,9 @@
             [witan.workspace-api :refer [defworkflowfn defworkflowpred]]
             [witan.datasets :as wds]
             [witan.models.dem.ccm.schemas :refer :all]
-            [witan.models.dem.ccm.fert.fertility-mvp :as fert]
-            [witan.models.dem.ccm.mort.mortality-mvp :as mort]
-            [witan.models.dem.ccm.mig.net-migration :as mig]
+            [witan.models.dem.ccm.fert.fertility :as fert]
+            [witan.models.dem.ccm.mort.mortality :as mort]
+            [witan.models.dem.ccm.mig.migration :as mig]
             [taoensso.timbre :as timbre]))
 
 (defworkflowfn keep-looping?

--- a/src/witan/models/dem/ccm/fert/fertility.clj
+++ b/src/witan/models/dem/ccm/fert/fertility.clj
@@ -1,4 +1,4 @@
-(ns witan.models.dem.ccm.fert.fertility-mvp
+(ns witan.models.dem.ccm.fert.fertility
   (:require [witan.models.dem.ccm.components-functions :as cf]
             [witan.workspace-api :refer [defworkflowfn]]
             [clojure.core.matrix.dataset :as ds]

--- a/src/witan/models/dem/ccm/mig/migration.clj
+++ b/src/witan/models/dem/ccm/mig/migration.clj
@@ -1,4 +1,4 @@
-(ns witan.models.dem.ccm.mig.net-migration
+(ns witan.models.dem.ccm.mig.migration
   (:require [witan.models.dem.ccm.components-functions :as cf]
             [witan.workspace-api :refer [defworkflowfn merge->]]
             [witan.datasets :as wds]

--- a/src/witan/models/dem/ccm/mort/mortality.clj
+++ b/src/witan/models/dem/ccm/mort/mortality.clj
@@ -1,4 +1,4 @@
-(ns witan.models.dem.ccm.mort.mortality-mvp
+(ns witan.models.dem.ccm.mort.mortality
   (:require [witan.models.dem.ccm.components-functions :as cf]
             [witan.workspace-api :refer [defworkflowfn]]
             [witan.datasets :as wds]

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -5,9 +5,9 @@
             [witan.models.load-data :as ld]
             [schema.core :as s]
             ;;
-            [witan.models.dem.ccm.fert.fertility-mvp]
-            [witan.models.dem.ccm.mort.mortality-mvp]
-            [witan.models.dem.ccm.mig.net-migration]
+            [witan.models.dem.ccm.fert.fertility]
+            [witan.models.dem.ccm.mort.mortality]
+            [witan.models.dem.ccm.mig.migration]
             [witan.models.dem.ccm.core.projection-loop]
             [witan.models.dem.ccm.models :refer [ccm-workflow]]
             [witan.models.dem.ccm.models-utils :refer [make-catalog make-contracts]]))
@@ -17,38 +17,38 @@
 (def tasks
   { ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Functions
-   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-asfr-finalyrhist-fixed}
+   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility/project-asfr-finalyrhist-fixed}
    :join-popn-latest-yr        {:var #'witan.models.dem.ccm.core.projection-loop/join-popn-latest-yr}
    :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
-   :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-deaths-from-fixed-rates}
-   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-in-migrants
+   :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality/project-deaths-from-fixed-rates}
+   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.migration/project-domestic-in-migrants
                                 :params {:start-yr-avg-domin-mig 2003
                                          :end-yr-avg-domin-mig 2014}}
-   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality-mvp/calc-historic-asmr}
-   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-domestic-out-migrants
+   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality/calc-historic-asmr}
+   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.migration/project-domestic-out-migrants
                                 :params {:start-yr-avg-domout-mig 2003
                                          :end-yr-avg-domout-mig 2014}}
    :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
    :age-on                     {:var #'witan.models.dem.ccm.core.projection-loop/age-on}
-   :project-births             {:var #'witan.models.dem.ccm.fert.fertility-mvp/project-births-from-fixed-rates}
-   :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility-mvp/combine-into-births-by-sex
+   :project-births             {:var #'witan.models.dem.ccm.fert.fertility/project-births-from-fixed-rates}
+   :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility/combine-into-births-by-sex
                                 :params {:proportion-male-newborns (double (/ 105 205))}}
-   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality-mvp/project-asmr
+   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality/project-asmr
                                 :params {:start-yr-avg-mort 2010
                                          :end-yr-avg-mort 2014}}
    :select-starting-popn       {:var #'witan.models.dem.ccm.core.projection-loop/select-starting-popn}
    :prepare-starting-popn      {:var #'witan.models.dem.ccm.core.projection-loop/prepare-inputs}
-   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility-mvp/calculate-historic-asfr
+   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility/calculate-historic-asfr
                                 :params {:fert-base-yr 2014}}
    :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
-   :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.net-migration/project-international-in-migrants
+   :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.migration/project-international-in-migrants
                                 :params {:start-yr-avg-intin-mig 2003
                                          :end-yr-avg-intin-mig 2014}}
-   :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.net-migration/project-international-out-migrants
+   :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.migration/project-international-out-migrants
                                 :params {:start-yr-avg-intout-mig 2003
                                          :end-yr-avg-intout-mig 2014}}
 
-   :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.net-migration/combine-into-net-flows}
+   :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.migration/combine-into-net-flows}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Predicates
    :finish-looping?            {:var #'witan.models.dem.ccm.core.projection-loop/finished-looping?

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -5,9 +5,9 @@
             [incanter.core :as i]
             [witan.models.load-data :as ld]
             [witan.datasets :as wds]
-            [witan.models.dem.ccm.fert.fertility-mvp :as fert]
-            [witan.models.dem.ccm.mort.mortality-mvp :as mort]
-            [witan.models.dem.ccm.mig.net-migration :as mig]))
+            [witan.models.dem.ccm.fert.fertility :as fert]
+            [witan.models.dem.ccm.mort.mortality :as mort]
+            [witan.models.dem.ccm.mig.migration :as mig]))
 
 ;; Load testing data
 (def data-inputs (ld/load-datasets

--- a/test/witan/models/dem/ccm/fert/fertility_test.clj
+++ b/test/witan/models/dem/ccm/fert/fertility_test.clj
@@ -1,5 +1,5 @@
-(ns witan.models.dem.ccm.fert.fertility-mvp-test
-  (:require [witan.models.dem.ccm.fert.fertility-mvp :refer :all]
+(ns witan.models.dem.ccm.fert.fertility-test
+  (:require [witan.models.dem.ccm.fert.fertility :refer :all]
             [witan.models.load-data :as ld]
             [clojure.test :refer :all]
             [incanter.core :as i]

--- a/test/witan/models/dem/ccm/mig/migration_test.clj
+++ b/test/witan/models/dem/ccm/mig/migration_test.clj
@@ -1,5 +1,5 @@
-(ns witan.models.dem.ccm.mig.net-migration-test
-  (:require [witan.models.dem.ccm.mig.net-migration :refer :all]
+(ns witan.models.dem.ccm.mig.migration-test
+  (:require [witan.models.dem.ccm.mig.migration :refer :all]
             [witan.models.load-data :as ld]
             [clojure.test :refer :all]
             [clojure.core.matrix.dataset :as ds]

--- a/test/witan/models/dem/ccm/mort/mortality_test.clj
+++ b/test/witan/models/dem/ccm/mort/mortality_test.clj
@@ -1,5 +1,5 @@
-(ns witan.models.dem.ccm.mort.mortality-mvp-test
-  (:require [witan.models.dem.ccm.mort.mortality-mvp :refer :all]
+(ns witan.models.dem.ccm.mort.mortality-test
+  (:require [witan.models.dem.ccm.mort.mortality :refer :all]
             [witan.models.load-data :as ld]
             [clojure.test :refer :all]
             [incanter.core :as i]

--- a/test/witan/models/run_models_test.clj
+++ b/test/witan/models/run_models_test.clj
@@ -7,9 +7,9 @@
             [witan.models.load-data :as ld]
             [witan.models.dem.ccm.core.projection-loop :as core]
             [witan.models.dem.ccm.core.projection-loop-test :as core-test]
-            [witan.models.dem.ccm.fert.fertility-mvp :as fert]
-            [witan.models.dem.ccm.mort.mortality-mvp :as mort]
-            [witan.models.dem.ccm.mig.net-migration :as mig]
+            [witan.models.dem.ccm.fert.fertility :as fert]
+            [witan.models.dem.ccm.mort.mortality :as mort]
+            [witan.models.dem.ccm.mig.migration :as mig]
             [witan.models.dem.ccm.components-functions :as cf]))
 
 (defn- fp-equals? [x y ε] (< (Math/abs (- x y)) ε))


### PR DESCRIPTION
- remove mvp suffix from fertility and mortality namespaces
- remove net prefix from migration namespace

This simplifies the naming of the ns in a sensible way to: fertility, mortality and migration.

This also generalises the naming, therefore may have to reconsider/revisit if the number of fns grow considerably
