### PR TITLE
Fix `load-data` location

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,8 @@
 machine:
   environment:
     _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+
+test:
+  override:
+    - lein test
+    - lein uberjar

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [prismatic/schema "1.1.3"]
                  [net.mikera/core.matrix "0.52.2"]
                  [org.clojure/data.csv "0.1.3"]
-                 [witan.workspace-api "0.1.17"]
+                 [witan.workspace-api "0.1.18"]
                  [org.clojure/tools.cli "0.3.5"]
                  [com.taoensso/timbre "4.7.3"]]
   :target-path "target/%s"

--- a/src-cli/witan/models/load_data.clj
+++ b/src-cli/witan/models/load_data.clj
@@ -5,7 +5,9 @@
             [schema.coerce :as coerce]
             [clojure.core.matrix.dataset :as ds]
             [witan.models.dem.ccm.schemas :refer :all]
-            [witan.workspace-api.utils :as utils]))
+            [witan.workspace-api.utils :as utils]
+            [witan.workspace-api :refer [defworkflowinput]]
+            [schema.core :as s]))
 
 (defn- custom-keyword [coll]
   (mapv #(-> %
@@ -201,3 +203,13 @@
   (->> file-map
        (mapv (fn [[k path]] (load-dataset k path)))
        (reduce merge)))
+
+(defworkflowinput resource-csv-loader
+  "Loads CSV files from resources"
+  {:witan/name :workspace-test/resource-csv-loader
+   :witan/version "1.0.0"
+   :witan/output-schema {:* s/Any}
+   :witan/param-schema {:src s/Str
+                        :key s/Keyword}}
+  [_ {:keys [src key]}]
+  (load-dataset key src))

--- a/src-cli/witan/models/run_models.clj
+++ b/src-cli/witan/models/run_models.clj
@@ -177,7 +177,7 @@
                                    :params {:gss-code gss-code
                                             :src (:historic-population inputs)
                                             :key :historic-population}}
-   :in-future-mort-trend          {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-future-mort-trend          {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src (:future-mortality-trend-assumption inputs)
                                             :key :future-mortality-trend-assumption}}
    :in-hist-total-births          {:var #'witan.models.run-models/resource-csv-loader-filtered

--- a/src/witan/models/dem/ccm/models_utils.clj
+++ b/src/witan/models/dem/ccm/models_utils.clj
@@ -3,7 +3,6 @@
             [witan.workspace-api :refer [defworkflowfn
                                          defworkflowoutput
                                          defworkflowinput]]
-            [witan.models.load-data :as ld]
             [schema.core :as s]))
 
 (defn year? [n] (and (>= n 1900) (<= n 2100)))
@@ -26,16 +25,6 @@
             (if (:params v)
               (assoc m :witan/params (:params v))
               m))) task-coll))
-
-(defworkflowinput resource-csv-loader
-  "Loads CSV files from resources"
-  {:witan/name :workspace-test/resource-csv-loader
-   :witan/version "1.0.0"
-   :witan/output-schema {:* s/Any}
-   :witan/param-schema {:src s/Str
-                        :key s/Keyword}}
-  [_ {:keys [src key]}]
-  (ld/load-dataset key src))
 
 (defworkflowfn fn-out
   {:witan/name :workspace-test/fn-out

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -58,31 +58,31 @@
                                 :params {:last-proj-yr 2021}}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Inputs
-   :in-hist-popn                  {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-popn                  {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/bristol_hist_popn_mye.csv"
                                             :key :historic-population}}
-   :in-hist-total-births          {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-total-births          {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_hist_births_mye.csv"
                                             :key :historic-births}}
-   :in-future-mort-trend          {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-future-mort-trend          {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/mort/death_improvement.csv"
                                             :key :future-mortality-trend-assumption}}
-   :in-proj-births-by-age-of-mother  {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-proj-births-by-age-of-mother  {:var #'witan.models.load-data/resource-csv-loader
                                       :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
                                                :key :ons-proj-births-by-age-mother}}
-   :in-hist-deaths-by-age-and-sex {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-deaths-by-age-and-sex {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/mort/bristol_hist_deaths_mye.csv"
                                             :key :historic-deaths}}
-   :in-hist-dom-in-migrants       {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-dom-in-migrants       {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_inmigrants.csv"
                                             :key :domestic-in-migrants}}
-   :in-hist-dom-out-migrants      {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-dom-out-migrants      {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_outmigrants.csv"
                                             :key :domestic-out-migrants}}
-   :in-hist-intl-in-migrants      {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-intl-in-migrants      {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_inmigrants.csv"
                                             :key :international-in-migrants}}
-   :in-hist-intl-out-migrants     {:var #'witan.models.dem.ccm.models-utils/resource-csv-loader
+   :in-hist-intl-out-migrants     {:var #'witan.models.load-data/resource-csv-loader
                                    :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_outmigrants.csv"
                                             :key :international-out-migrants}}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
`load-data` was moved to the `src-cli` directory but still referenced in `model-utils`. This prevented an uberjar being created.
