### PR TITLE
Add schema to input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/datasets/default_datasets/*/*_E0*.csv

--- a/README.md
+++ b/README.md
@@ -191,15 +191,26 @@ The [default config file](https://github.com/MastodonC/witan.models.demography/b
 
 This is the path to the file where the final projection should be saved. The projections are returned in one csv file. This file contains the historical population data used in the projection, with the projected population appended. The output path can be anywhere on your machine as long as the directories on the path exist.
 
-## Uploading data
+## Splitting and Uploading data
 
-To upload all the default datasets to S3, use
+By default, the data for the CCM is amalgamated into single data files.
+To split the files by GSS code, use the following command:
 
 ```
-lein upload
+lein split-data
 ```
 
-This assumes a valid AWS profile, called 'witan', is installed.
+To upload all the CSV files to S3 (gzipped), use the following command:
+
+```
+lein upload-data
+```
+
+This assumes a valid AWS profile, called 'witan', is installed. For ease, these commands can be chained like so:
+
+```
+lein do split-data, upload-data
+```
 
 ## License
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,5 +6,6 @@ machine:
 
 test:
   override:
+    - lein split-data
     - lein test
     - lein uberjar

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [prismatic/schema "1.1.3"]
                  [net.mikera/core.matrix "0.52.2"]
                  [org.clojure/data.csv "0.1.3"]
-                 [witan.workspace-api "0.1.18"]
+                 [witan.workspace-api "0.1.19-SNAPSHOT"]
                  [org.clojure/tools.cli "0.3.5"]
                  [com.taoensso/timbre "4.7.3"]]
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [prismatic/schema "1.1.3"]
                  [net.mikera/core.matrix "0.52.2"]
                  [org.clojure/data.csv "0.1.3"]
-                 [witan.workspace-api "0.1.19-SNAPSHOT"]
+                 [witan.workspace-api "0.1.19"]
                  [org.clojure/tools.cli "0.3.5"]
                  [com.taoensso/timbre "4.7.3"]]
   :target-path "target/%s"
@@ -19,8 +19,9 @@
                    :source-paths ["src" "src-cli"]
                    :dependencies [[witan.workspace-executor "0.2.3"
                                    :exclusions [witan.workspace-api]]]}
-             :data {:main witan.models.upload-data
-                    :source-paths ["src-data"]
-                    :dependencies [[amazonica "0.3.73"]]}}
+             :data {:source-paths ["src-data"]
+                    :dependencies [[amazonica "0.3.73"]
+                                   [me.raynes/fs "1.4.6"]]}}
   :exclusions [prismatic/schema org.clojure/clojure]
-  :aliases {"upload" ["with-profile" "data" "run"]})
+  :aliases {"split-data"  ["with-profile" "data" "run" "-m" "witan.models.split-data"]
+            "upload-data" ["with-profile" "data" "run" "-m" "witan.models.upload-data"]})

--- a/src-data/witan/models/data_config.clj
+++ b/src-data/witan/models/data_config.clj
@@ -1,0 +1,11 @@
+(ns witan.models.data-config)
+
+(def default-bucket    "witan-data")
+(def default-profile   "witan")
+(def default-directory "datasets/default_datasets")
+(def default-folder    "witan.models.demography")
+
+(defn valid?
+  [filename-regex file]
+  (and (not (.isDirectory file))
+       (re-find filename-regex (str file))))

--- a/src-data/witan/models/split_data.clj
+++ b/src-data/witan/models/split_data.clj
@@ -1,0 +1,47 @@
+(ns witan.models.split-data
+  (:require [clojure.string :as str]
+            [amazonica.aws.s3 :as aws]
+            [amazonica.aws.s3transfer :as aws-s3]
+            [clojure.data.csv :as data-csv]
+            [clojure.java.io :as io]
+            [witan.models.data-config :as dc]
+            [me.raynes.fs :as fs])
+  (:gen-class))
+
+(defn write-new-file
+  [{:keys [path data]}]
+  (println "Writing" path)
+  (with-open [out-file (io/writer path)]
+    (data-csv/write-csv out-file data)))
+
+(defn split-files-by-gss-code
+  [files]
+  (reduce (fn [a file]
+            (let [parsed-csv (data-csv/read-csv (slurp file))
+                  parsed-data (rest parsed-csv)
+                  headers (map str/lower-case (first parsed-csv))
+                  gss-code-idx (.indexOf headers "gss.code")]
+              (if (>= gss-code-idx 0)
+                (let [grouped-by-gss-code (group-by #(nth % gss-code-idx) parsed-data)
+                      new-files (mapv (fn [[gss-code data]]
+                                        (let [name   (str file)
+                                              name'  (subs name 0 (- (count name) 4))
+                                              name'' (str name' "_" gss-code ".csv")]
+                                          {:path name''
+                                           :data (concat [headers] data)})) grouped-by-gss-code)
+                      _ (run! write-new-file new-files)
+                      new-file-names (mapv :path new-files)]
+                  (concat
+                   (conj a (str file))
+                   new-file-names))
+                (conj a (str file))))) [] files))
+
+
+(defn -main
+  "Splits the data into GSS code"
+  []
+  (time
+   (let [dir (clojure.java.io/file dc/default-directory)
+         files (file-seq dir)
+         valid-files (filter (partial dc/valid? #"[a-zA-Z]+.csv$") files)]
+     (split-files-by-gss-code valid-files))))

--- a/src-data/witan/models/upload_data.clj
+++ b/src-data/witan/models/upload_data.clj
@@ -1,35 +1,41 @@
 (ns witan.models.upload-data
   (:require [clojure.string :as str]
             [amazonica.aws.s3 :as aws]
-            [amazonica.aws.s3transfer :as aws-s3])
+            [amazonica.aws.s3transfer :as aws-s3]
+            [clojure.data.csv :as data-csv]
+            [clojure.java.io :as io]
+            [witan.models.data-config :as dc]
+            [me.raynes.fs :as fs])
+  (:import java.util.zip.GZIPOutputStream)
   (:gen-class))
 
-(def default-bucket    "witan-data")
-(def default-profile   "witan")
-(def default-directory "datasets/default_datasets")
-(def default-folder    "witan.models.demography")
-(def filename-regex    #".csv")
+(defn gzip
+  [input output & opts]
+  (with-open [output (-> output io/output-stream GZIPOutputStream.)]
+    (apply io/copy input output opts)))
 
 (defn upload-file
   [dir bucket file]
-  (let [name (->>
+  (let [tmpfile (fs/temp-file "ccm" ".txt.gz")
+        _ (with-open [in (io/input-stream file)
+                      out (io/output-stream tmpfile)]
+            (gzip in out))
+        name (->>
               (str/replace (str file) (str dir) "")
-              (str default-folder))]
-    (println "Uploading" (str file) "to" name)
-    (aws/put-object {:profile default-profile}
+              (str dc/default-folder))
+        name' (str name ".gz")]
+    (println "Uploading" (str file) "to" name')
+    (aws/put-object {:profile dc/default-profile}
                     :bucket-name bucket
-                    :key name
-                    :file file)))
-
-(defn valid?
-  [file]
-  (and (not (.isDirectory file))
-       (re-find filename-regex (str file))))
+                    :key name'
+                    :file tmpfile)
+    (fs/delete (str tmpfile))))
 
 (defn -main
   "Uploads the data to S3"
   []
-  (let [dir (clojure.java.io/file default-directory)
-        files (file-seq dir)
-        valid-files (filter valid? files)]
-    (run! (partial upload-file dir default-bucket) valid-files)))
+  (time
+   (let [dir (clojure.java.io/file dc/default-directory)
+         files (file-seq dir)
+         valid-files (filter (partial dc/valid? #".csv$") files)]
+     (run! (partial upload-file dir dc/default-bucket) valid-files))))

--- a/src/witan/models/dem/ccm/inputs.clj
+++ b/src/witan/models/dem/ccm/inputs.clj
@@ -1,0 +1,57 @@
+(ns witan.models.dem.ccm.inputs
+  (:require [witan.workspace-api :refer [definput]]
+            [witan.models.dem.ccm.schemas :as s]))
+
+(definput in-hist-deaths-by-age-and-sex-1-0-0
+  {:witan/name :ccm-core-input/in-hist-deaths-by-age-and-sex
+   :witan/version "1.0.0"
+   :witan/key :historic-deaths
+   :witan/schema s/DeathsSchema})
+
+(definput in-hist-dom-in-migrants-1-0-0
+  {:witan/name :ccm-core-input/in-hist-dom-in-migrants
+   :witan/version "1.0.0"
+   :witan/key :domestic-in-migrants
+   :witan/schema s/DomesticInmigrants})
+
+(definput in-hist-dom-out-migrants-1-0-0
+  {:witan/name :ccm-core-input/in-hist-dom-out-migrants
+   :witan/version "1.0.0"
+   :witan/key :domestic-out-migrants
+   :witan/schema s/DomesticOutmigrants})
+
+(definput in-hist-intl-in-migrants-1-0-0
+  {:witan/name :ccm-core-input/in-hist-intl-in-migrants
+   :witan/version "1.0.0"
+   :witan/key :international-in-migrants
+   :witan/schema s/InternationalInmigrants})
+
+(definput in-hist-intl-out-migrants-1-0-0
+  {:witan/name :ccm-core-input/in-hist-intl-out-migrants
+   :witan/version "1.0.0"
+   :witan/key :international-out-migrants
+   :witan/schema s/InternationalOutmigrants})
+
+(definput in-hist-popn-1-0-0
+  {:witan/name :ccm-core-input/in-hist-popn
+   :witan/version "1.0.0"
+   :witan/key :historic-population
+   :witan/schema s/PopulationSchema})
+
+(definput in-future-mort-trend-1-0-0
+  {:witan/name :ccm-core-input/in-future-mort-trend
+   :witan/version "1.0.0"
+   :witan/key :future-mortality-trend-assumption
+   :witan/schema s/NationalTrendsSchema})
+
+(definput in-hist-total-births-1-0-0
+  {:witan/name :ccm-core-input/in-hist-total-births
+   :witan/version "1.0.0"
+   :witan/key :historic-births
+   :witan/schema s/BirthsSchema})
+
+(definput in-proj-births-by-age-of-mother-1-0-0
+  {:witan/name :ccm-core-input/in-proj-births-by-age-of-mother
+   :witan/version "1.0.0"
+   :witan/key :ons-proj-births-by-age-mother
+   :witan/schema s/BirthsAgeSexMotherSchema})

--- a/src/witan/models/dem/ccm/inputs.clj
+++ b/src/witan/models/dem/ccm/inputs.clj
@@ -53,5 +53,5 @@
 (definput in-proj-births-by-age-of-mother-1-0-0
   {:witan/name :ccm-core-input/in-proj-births-by-age-of-mother
    :witan/version "1.0.0"
-   :witan/key :ons-proj-births-by-age-mother
+   :witan/key :historic-births-by-age-mother
    :witan/schema s/BirthsAgeSexMotherSchema})

--- a/src/witan/models/dem/ccm/models.clj
+++ b/src/witan/models/dem/ccm/models.clj
@@ -1,8 +1,10 @@
 (ns witan.models.dem.ccm.models
-  (:require [witan.workspace-api :refer [defmodel]]
+  (:require [witan.workspace-api :refer [defmodel
+                                         definput]]
             [witan.workspace-api.utils :refer [map-fn-meta
                                                map-model-meta]]
             [witan.workspace-api.protocols :as p]
+            [witan.models.dem.ccm.inputs           :as inputs]
             [witan.models.dem.ccm.mort.mortality   :as mort]
             [witan.models.dem.ccm.fert.fertility   :as fert]
             [witan.models.dem.ccm.mig.migration    :as mig]
@@ -89,66 +91,56 @@
     {:witan/name :in-hist-deaths-by-age-and-sex
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
-     :witan/params
-     {:src "witan.models.demography/mortality/historic_deaths.csv"
-      :key :historic-deaths}}
+     :witan/fn :ccm-core-input/in-hist-deaths-by-age-and-sex
+     :witan/params {:src "witan.models.demography/mortality/historic_deaths.csv"}}
     {:witan/name :in-hist-dom-in-migrants
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-hist-dom-in-migrants
      :witan/params
-     {:src "witan.models.demography/migration/domestic_in_migrants.csv"
-      :key :domestic-in-migrants}}
+     {:src "witan.models.demography/migration/domestic_in_migrants.csv"}}
     {:witan/name :in-hist-dom-out-migrants
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-hist-dom-out-migrants
      :witan/params
-     {:src "witan.models.demography/migration/domestic_out_migrants.csv"
-      :key :domestic-out-migrants}}
+     {:src "witan.models.demography/migration/domestic_out_migrants.csv"}}
     {:witan/name :in-hist-intl-in-migrants
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-hist-intl-in-migrants
      :witan/params
-     {:src "witan.models.demography/migration/international_in_migrants.csv"
-      :key :international-in-migrants}}
+     {:src "witan.models.demography/migration/international_in_migrants.csv"}}
     {:witan/name :in-hist-intl-out-migrants
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-hist-intl-out-migrants
      :witan/params
-     {:src "witan.models.demography/migration/international_out_migrants.csv"
-      :key :international-out-migrants}}
+     {:src "witan.models.demography/migration/international_out_migrants.csv"}}
     {:witan/name :in-hist-popn
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-hist-popn
      :witan/params
-     {:src "witan.models.demography/core/historic-population.csv"
-      :key :historic-population}}
+     {:src "witan.models.demography/core/historic-population.csv"}}
     {:witan/name :in-future-mort-trend
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-future-mort-trend
      :witan/params
-     {:src "witan.models.demography/mortality/death_improvement.csv"
-      :key :future-mortality-trend-assumption}}
+     {:src "witan.models.demography/mortality/death_improvement.csv"}}
     {:witan/name :in-hist-total-births
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader,
+     :witan/fn :ccm-core-input/in-hist-total-births
      :witan/params
-     {:src "witan.models.demography/fertility/historic_births.csv"
-      :key :historic-births}}
+     {:src "witan.models.demography/fertility/historic_births.csv"}}
     {:witan/name :in-proj-births-by-age-of-mother
      :witan/version "1.0.0"
      :witan/type :input
-     :witan/fn :workspace-test/resource-csv-loader
+     :witan/fn :ccm-core-input/in-proj-births-by-age-of-mother
      :witan/params
-     {:src "witan.models.demography/fertility/proj-births-by-age-mother.csv"
-      :key :historic-births-by-age-mother}}
+     {:src "witan.models.demography/fertility/proj-births-by-age-mother.csv"}}
     {:witan/name :join-popn-latest-year
      :witan/version "1.0.0"
      :witan/type :function
@@ -165,12 +157,12 @@
      :witan/version "1.0.0"
      :witan/type :function
      :witan/fn :ccm-mig/proj-dom-in-mig
-     :witan/params {:start-year-avg-dom-mig 2003, :end-year-avg-dom-mig 2014}}
+     :witan/params {:start-year-avg-domin-mig 2003, :end-year-avg-domin-mig 2014}}
     {:witan/name :proj-dom-out-migrants
      :witan/version "1.0.0"
      :witan/type :function
      :witan/fn :ccm-mig/proj-dom-out-mig
-     :witan/params {:start-year-avg-dom-mig 2003, :end-year-avg-dom-mig 2014}}
+     :witan/params {:start-year-avg-domout-mig 2003, :end-year-avg-domout-mig 2014}}
     {:witan/name :project-asfr
      :witan/version "1.0.0"
      :witan/type :function
@@ -185,12 +177,13 @@
      :witan/version "1.0.0"
      :witan/type :function
      :witan/fn :ccm-mig/proj-inter-in-mig
-     :witan/params {:start-year-avg-inter-mig 2003, :end-year-avg-inter-mig 2014}}
+     :witan/params {:start-year-avg-intin-mig 2003,
+                    :end-year-avg-intin-mig 2014}}
     {:witan/name :proj-intl-out-migrants
      :witan/version "1.0.0"
      :witan/type :function
      :witan/fn :ccm-mig/proj-inter-out-mig
-     :witan/params {:start-year-avg-inter-mig 2003, :end-year-avg-inter-mig 2014}}
+     :witan/params {:start-year-avg-intout-mig 2003, :end-year-avg-intout-mig 2014}}
     {:witan/name :combine-into-births-by-sex
      :witan/version "1.0.0"
      :witan/type :function
@@ -222,6 +215,17 @@
   (reify p/IModelLibrary
     (available-fns [_]
       (map-fn-meta
+       ;; inputs
+       inputs/in-hist-deaths-by-age-and-sex-1-0-0
+       inputs/in-hist-dom-in-migrants-1-0-0
+       inputs/in-hist-dom-out-migrants-1-0-0
+       inputs/in-hist-intl-in-migrants-1-0-0
+       inputs/in-hist-intl-out-migrants-1-0-0
+       inputs/in-hist-popn-1-0-0
+       inputs/in-future-mort-trend-1-0-0
+       inputs/in-hist-total-births-1-0-0
+       inputs/in-proj-births-by-age-of-mother-1-0-0
+
        ;; fertility fns
        fert/project-asfr-finalyearhist-fixed
        fert/project-births-from-fixed-rates

--- a/src/witan/models/dem/ccm/models.clj
+++ b/src/witan/models/dem/ccm/models.clj
@@ -10,6 +10,10 @@
             [witan.models.dem.ccm.mig.migration    :as mig]
             [witan.models.dem.ccm.core.projection-loop :as core]))
 
+(defn with-gss
+  [id]
+  (str id "_{{GSS-Code}}.csv.gz"))
+
 (defmodel cohort-component-model
   "The CCM model"
   {:witan/name :ccm-model/cohort-component-model
@@ -92,55 +96,55 @@
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-deaths-by-age-and-sex
-     :witan/params {:src "witan.models.demography/mortality/historic_deaths.csv"}}
+     :witan/params {:src (with-gss "witan.models.demography/mortality/historic_deaths")}}
     {:witan/name :in-hist-dom-in-migrants
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-dom-in-migrants
      :witan/params
-     {:src "witan.models.demography/migration/domestic_in_migrants.csv"}}
+     {:src (with-gss "witan.models.demography/migration/domestic_in_migrants")}}
     {:witan/name :in-hist-dom-out-migrants
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-dom-out-migrants
      :witan/params
-     {:src "witan.models.demography/migration/domestic_out_migrants.csv"}}
+     {:src (with-gss "witan.models.demography/migration/domestic_out_migrants")}}
     {:witan/name :in-hist-intl-in-migrants
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-intl-in-migrants
      :witan/params
-     {:src "witan.models.demography/migration/international_in_migrants.csv"}}
+     {:src (with-gss "witan.models.demography/migration/international_in_migrants")}}
     {:witan/name :in-hist-intl-out-migrants
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-intl-out-migrants
      :witan/params
-     {:src "witan.models.demography/migration/international_out_migrants.csv"}}
+     {:src (with-gss "witan.models.demography/migration/international_out_migrants")}}
     {:witan/name :in-hist-popn
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-popn
      :witan/params
-     {:src "witan.models.demography/core/historic-population.csv"}}
+     {:src (with-gss "witan.models.demography/core/historic-population")}}
     {:witan/name :in-future-mort-trend
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-future-mort-trend
      :witan/params
-     {:src "witan.models.demography/mortality/death_improvement.csv"}}
+     {:src (with-gss "witan.models.demography/mortality/death_improvement")}}
     {:witan/name :in-hist-total-births
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-hist-total-births
      :witan/params
-     {:src "witan.models.demography/fertility/historic_births.csv"}}
+     {:src (with-gss "witan.models.demography/fertility/historic_births")}}
     {:witan/name :in-proj-births-by-age-of-mother
      :witan/version "1.0.0"
      :witan/type :input
      :witan/fn :ccm-core-input/in-proj-births-by-age-of-mother
      :witan/params
-     {:src "witan.models.demography/fertility/proj-births-by-age-mother.csv"}}
+     {:src (with-gss "witan.models.demography/fertility/proj-births-by-age-mother")}}
     {:witan/name :join-popn-latest-year
      :witan/version "1.0.0"
      :witan/type :function

--- a/src/witan/models/dem/ccm/schemas.clj
+++ b/src/witan/models/dem/ccm/schemas.clj
@@ -25,101 +25,101 @@
 ;;Historic data used in core loop & component modules
 (def DomesticInmigrants
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:domin double]]))
+                           [:year s/Int] [:domin java.lang.Double]]))
 
 (def DomesticOutmigrants
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:domout double]]))
+                           [:year s/Int] [:domout java.lang.Double]]))
 
 (def InternationalInmigrants
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:intin double]]))
+                           [:year s/Int] [:intin java.lang.Double]]))
 
 (def InternationalOutmigrants
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:intout double]]))
+                           [:year s/Int] [:intout java.lang.Double]]))
 (def DeathsSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:deaths double]]))
+                           [:year s/Int] [:deaths java.lang.Double]]))
 
 (def BirthsSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:births double]]))
+                           [:year s/Int] [:births java.lang.Double]]))
 
 ;;For core CCM projection loop using fert/mort/mig inputs from files
 (def BirthsBySexSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:births double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:births java.lang.Double]]))
 
 (def DeathsOutputSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:year s/Int]
-                           [:deaths double]]))
+                           [:deaths java.lang.Double]]))
 
 (def NetMigrationSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:net-mig double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:net-mig java.lang.Double]]))
 
 ;;For load-data test
 (def BirthsDataSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:births double] [:year s/Int]]))
+                           [:births java.lang.Double] [:year s/Int]]))
 
 ;; For the migration component
 (def ProjDomInSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:domestic-in double]]))
+                           [:domestic-in java.lang.Double]]))
 
 (def ProjDomOutSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:domestic-out double]]))
+                           [:domestic-out java.lang.Double]]))
 
 (def ProjInterInSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:international-in double]]))
+                           [:international-in java.lang.Double]]))
 
 (def ProjInterOutSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:international-out double]]))
+                           [:international-out java.lang.Double]]))
 
 (def DomInAverageSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:domin double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:domin java.lang.Double]]))
 
 (def DomOutAverageSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:domout double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:domout java.lang.Double]]))
 
 (def InterInAverageSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:intin double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:intin java.lang.Double]]))
 
 (def InterOutAverageSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:intout double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:intout java.lang.Double]]))
 
 ;; For the core module
 (def PopulationSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:popn double]]))
+                           [:year s/Int] [:popn java.lang.Double]]))
 
 (def PopulationAtRiskSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:popn-at-risk double]]))
+                           [:year s/Int] [:popn-at-risk java.lang.Double]]))
 
 ;; For the mortality component
 (def HistASMRSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:death-rate double]]))
+                           [:year s/Int] [:death-rate java.lang.Double]]))
 
 (def ProjASMRSchema
-  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:year s/Int] [:death-rate double]]))
+  (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int] [:year s/Int] [:death-rate java.lang.Double]]))
 
 (def NationalTrendsSchema
-  (make-ordered-ds-schema [[:sex s/Str] [:age s/Int] [:year s/Int] [:principal double]
-                           [:low double] [:high double]]))
+  (make-ordered-ds-schema [[:sex s/Str] [:age s/Int] [:year s/Int] [:principal java.lang.Double]
+                           [:low java.lang.Double] [:high java.lang.Double]]))
 
 ;; For the fertility component
 (def HistASFRSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:fert-rate double]]))
+                           [:year s/Int] [:fert-rate java.lang.Double]]))
 
 (def ProjFixedASFRSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:fert-rate double]]))
+                           [:fert-rate java.lang.Double]]))
 (def BirthsAgeSexMotherSchema
   (make-ordered-ds-schema [[:gss-code s/Str] [:sex s/Str] [:age s/Int]
-                           [:year s/Int] [:births double]]))
+                           [:year s/Int] [:births java.lang.Double]]))

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -15,88 +15,63 @@
                                                  model-library]]
             [witan.models.dem.ccm.models-utils :refer [make-catalog make-contracts]]))
 
-(def tasks
-  {;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-   ;; Functions
-   :project-asfr               {:var #'witan.models.dem.ccm.fert.fertility/project-asfr-finalyearhist-fixed}
-   :join-popn-latest-year        {:var #'witan.models.dem.ccm.core.projection-loop/join-popn-latest-year}
-   :add-births                 {:var #'witan.models.dem.ccm.core.projection-loop/add-births}
-   :project-deaths             {:var #'witan.models.dem.ccm.mort.mortality/project-deaths}
-   :proj-dom-in-migrants       {:var #'witan.models.dem.ccm.mig.migration/project-domestic-in-migrants
-                                :params {:start-year-avg-domin-mig 2003
-                                         :end-year-avg-domin-mig 2014}}
-   :calc-hist-asmr             {:var #'witan.models.dem.ccm.mort.mortality/calc-historic-asmr}
-   :proj-dom-out-migrants      {:var #'witan.models.dem.ccm.mig.migration/project-domestic-out-migrants
-                                :params {:start-year-avg-domout-mig 2003
-                                         :end-year-avg-domout-mig 2014}}
-   :remove-deaths              {:var #'witan.models.dem.ccm.core.projection-loop/remove-deaths}
-   :age-on                     {:var #'witan.models.dem.ccm.core.projection-loop/age-on}
-   :project-births             {:var #'witan.models.dem.ccm.fert.fertility/project-births-from-fixed-rates}
-   :combine-into-births-by-sex {:var #'witan.models.dem.ccm.fert.fertility/combine-into-births-by-sex
-                                :params {:proportion-male-newborns (double (/ 105 205))}}
-   :project-asmr               {:var #'witan.models.dem.ccm.mort.mortality/project-asmr-1-0-0
-                                :params {:start-year-avg-mort 2010
-                                         :end-year-avg-mort 2014
-                                         :last-proj-year 2021
-                                         :first-proj-year 2014}}
-   :select-starting-popn       {:var #'witan.models.dem.ccm.core.projection-loop/select-starting-popn}
-   :prepare-starting-popn      {:var #'witan.models.dem.ccm.core.projection-loop/prepare-inputs}
-   :calc-hist-asfr             {:var #'witan.models.dem.ccm.fert.fertility/calculate-historic-asfr
-                                :params {:fert-base-year 2014}}
-   :apply-migration            {:var #'witan.models.dem.ccm.core.projection-loop/apply-migration}
-   :proj-intl-in-migrants      {:var #'witan.models.dem.ccm.mig.migration/project-international-in-migrants
-                                :params {:start-year-avg-intin-mig 2003
-                                         :end-year-avg-intin-mig 2014}}
-   :proj-intl-out-migrants     {:var #'witan.models.dem.ccm.mig.migration/project-international-out-migrants
-                                :params {:start-year-avg-intout-mig 2003
-                                         :end-year-avg-intout-mig 2014}}
+(def local-inputs
+  {:ccm-core-input/in-hist-popn
+   [:historic-population
+    "./datasets/test_datasets/model_inputs/bristol_hist_popn_mye.csv"]
 
-   :combine-into-net-flows {:var #'witan.models.dem.ccm.mig.migration/combine-into-net-flows}
-   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-   ;; Predicates
-   :finish-looping?            {:var #'witan.models.dem.ccm.core.projection-loop/finished-looping?
-                                :params {:last-proj-year 2021}}
-   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-   ;; Inputs
-   :in-hist-popn                  {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/bristol_hist_popn_mye.csv"
-                                            :key :historic-population}}
-   :in-hist-total-births          {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_hist_births_mye.csv"
-                                            :key :historic-births}}
-   :in-future-mort-trend          {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/mort/death_improvement.csv"
-                                            :key :future-mortality-trend-assumption}}
-   :in-proj-births-by-age-of-mother  {:var #'witan.models.load-data/resource-csv-loader
-                                      :params {:src "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
-                                               :key :historic-births-by-age-mother}}
-   :in-hist-deaths-by-age-and-sex {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/mort/bristol_hist_deaths_mye.csv"
-                                            :key :historic-deaths}}
-   :in-hist-dom-in-migrants       {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_inmigrants.csv"
-                                            :key :domestic-in-migrants}}
-   :in-hist-dom-out-migrants      {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_outmigrants.csv"
-                                            :key :domestic-out-migrants}}
-   :in-hist-intl-in-migrants      {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_inmigrants.csv"
-                                            :key :international-in-migrants}}
-   :in-hist-intl-out-migrants     {:var #'witan.models.load-data/resource-csv-loader
-                                   :params {:src "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_outmigrants.csv"
-                                            :key :international-out-migrants}}
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-   ;; Outputs
-   :out {:var #'witan.models.dem.ccm.models-utils/out}})
+   :ccm-core-input/in-hist-total-births
+   [:historic-births
+    "./datasets/test_datasets/model_inputs/fert/bristol_hist_births_mye.csv"]
+
+   :ccm-core-input/in-future-mort-trend
+   [:future-mortality-trend-assumption
+    "./datasets/test_datasets/model_inputs/mort/death_improvement.csv"]
+
+   :ccm-core-input/in-proj-births-by-age-of-mother
+   [:ons-proj-births-by-age-mother
+    "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"]
+
+   :ccm-core-input/in-hist-deaths-by-age-and-sex
+   [:historic-deaths
+    "./datasets/test_datasets/model_inputs/mort/bristol_hist_deaths_mye.csv"]
+
+   :ccm-core-input/in-hist-dom-in-migrants
+   [:domestic-in-migrants
+    "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_inmigrants.csv"]
+
+   :ccm-core-input/in-hist-dom-out-migrants
+   [:domestic-out-migrants
+    "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_outmigrants.csv"]
+
+   :ccm-core-input/in-hist-intl-in-migrants
+   [:international-in-migrants
+    "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_inmigrants.csv"]
+
+   :ccm-core-input/in-hist-intl-out-migrants
+   [:international-out-migrants
+    "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_outmigrants.csv"]})
+
+(defn local-download
+  [input _ schema]
+  (let [[key src] (get local-inputs (:witan/fn input))
+        r (ld/load-dataset key src)]
+    (get r key)))
+
+(defn fix-input
+  [input]
+  (assoc-in input [:witan/params :fn] (partial local-download input)))
 
 (deftest workspace-test
-  (let [workspace     {:workflow  (:workflow cohort-component-model)
-                       :catalog   (make-catalog tasks)
-                       :contracts (make-contracts tasks)}
+  (let [fixed-catalog (mapv #(if (= (:witan/type %) :input) (fix-input %) %) (:catalog cohort-component-model))
+        workspace     {:workflow  (:workflow cohort-component-model)
+                       :catalog   fixed-catalog
+                       :contracts (p/available-fns (model-library))}
         workspace'    (s/with-fn-validation (wex/build! workspace))
         result        (wex/run!! workspace' {})]
     (is (not-empty result))
-    (is (:finished? (first result)))))
+    (is (= 1 (count (first result))))
+    (is (contains? (first result) :population))))
 
 (deftest imodellibrary-test
   (let [ml (model-library)

--- a/test/witan/models/acceptance/workspace_test.clj
+++ b/test/witan/models/acceptance/workspace_test.clj
@@ -15,46 +15,53 @@
                                                  model-library]]
             [witan.models.dem.ccm.models-utils :refer [make-catalog make-contracts]]))
 
+(def gss-code "E07000155")
+
+(defn with-gss
+  [id]
+  (str id "_" gss-code ".csv"))
+
 (def local-inputs
   {:ccm-core-input/in-hist-popn
    [:historic-population
-    "./datasets/test_datasets/model_inputs/bristol_hist_popn_mye.csv"]
+    (with-gss "./datasets/default_datasets/core/historic_population")]
 
    :ccm-core-input/in-hist-total-births
    [:historic-births
-    "./datasets/test_datasets/model_inputs/fert/bristol_hist_births_mye.csv"]
+    (with-gss "./datasets/default_datasets/fertility/historic_births")]
 
    :ccm-core-input/in-future-mort-trend
    [:future-mortality-trend-assumption
-    "./datasets/test_datasets/model_inputs/mort/death_improvement.csv"]
+    "./datasets/default_datasets/mortality/future_mortality_trend_assumption.csv"]
 
    :ccm-core-input/in-proj-births-by-age-of-mother
-   [:ons-proj-births-by-age-mother
-    "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"]
+   [:historic-births-by-age-mother
+    (with-gss "./datasets/default_datasets/fertility/historic_births_by_age_of_mother")]
 
    :ccm-core-input/in-hist-deaths-by-age-and-sex
    [:historic-deaths
-    "./datasets/test_datasets/model_inputs/mort/bristol_hist_deaths_mye.csv"]
+    (with-gss "./datasets/default_datasets/mortality/historic_deaths")]
 
    :ccm-core-input/in-hist-dom-in-migrants
    [:domestic-in-migrants
-    "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_inmigrants.csv"]
+    (with-gss "./datasets/default_datasets/migration/historic_migration_flows_domestic_in")]
 
    :ccm-core-input/in-hist-dom-out-migrants
    [:domestic-out-migrants
-    "./datasets/test_datasets/model_inputs/mig/bristol_hist_domestic_outmigrants.csv"]
+    (with-gss "./datasets/default_datasets/migration/historic_migration_flows_domestic_out")]
 
    :ccm-core-input/in-hist-intl-in-migrants
    [:international-in-migrants
-    "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_inmigrants.csv"]
+    (with-gss "./datasets/default_datasets/migration/historic_migration_flows_international_in")]
 
    :ccm-core-input/in-hist-intl-out-migrants
    [:international-out-migrants
-    "./datasets/test_datasets/model_inputs/mig/bristol_hist_international_outmigrants.csv"]})
+    (with-gss "./datasets/default_datasets/migration/historic_migration_flows_international_out")]})
 
 (defn local-download
   [input _ schema]
-  (let [[key src] (get local-inputs (:witan/fn input))
+  (let [[key src] (get local-inputs (or (:witan/fn input)
+                                        (:witan/name input)))
         r (ld/load-dataset key src)]
     (get r key)))
 

--- a/test/witan/models/dem/ccm/inputs_test.clj
+++ b/test/witan/models/dem/ccm/inputs_test.clj
@@ -1,0 +1,10 @@
+(ns witan.models.dem.ccm.inputs-test
+  (:require [witan.models.dem.ccm.inputs :as sut]
+            [witan.models.acceptance.workspace-test :as wt]
+            [clojure.test :refer :all]))
+
+(deftest inputs
+  (is (contains? (sut/in-hist-deaths-by-age-and-sex-1-0-0
+                  nil {:src "./datasets/test_datasets/model_inputs/fert/bristol_ons_proj_births_age_mother.csv"
+                       :fn (partial wt/local-download (:witan/metadata (meta #'sut/in-hist-deaths-by-age-and-sex-1-0-0)))})
+                 :historic-deaths)))


### PR DESCRIPTION
Add two new features:
- Use of `definput` macro to further identify the inputs that are feeding into the model.
- `split-data` and `upload-data` as separate lein tasks that allow for pre-processing of the data and uploading of the pre-processed data (also now gzipped, for extra cool)
