### PR TITLE
Fix for workflow merge

### DIFF
--- a/src/witan/models/dem/ccm/models.clj
+++ b/src/witan/models/dem/ccm/models.clj
@@ -56,13 +56,12 @@
     [:combine-into-net-flows :select-starting-popn]
 
     ;; --- start popn loop
-    [:select-starting-popn       :project-births]
     [:select-starting-popn       :project-deaths]
+    [:project-deaths             :project-births]
     [:project-births             :combine-into-births-by-sex]
     [:combine-into-births-by-sex :age-on]
     [:age-on                     :add-births]
     [:add-births                 :remove-deaths]
-    [:project-deaths             :remove-deaths]
     [:remove-deaths              :apply-migration]
     [:apply-migration            :join-popn-latest-year]
     [:join-popn-latest-year      [:finish-looping? :out :select-starting-popn]]
@@ -91,7 +90,7 @@
      :witan/version "1.0.0"
      :witan/type :predicate
      :witan/fn :ccm-core/ccm-loop-pred
-     :witan/params {:last-proj-year 2021}}
+     :witan/params {:last-proj-year 2018}}
     {:witan/name :in-hist-deaths-by-age-and-sex
      :witan/version "1.0.0"
      :witan/type :input
@@ -175,7 +174,7 @@
      :witan/version "1.0.0",
      :witan/type :function,
      :witan/fn :ccm-mort/project-asmr
-     :witan/params {:start-year-avg-mort 2010, :end-year-avg-mort 2014, :last-proj-year 2021 :first-proj-year 2014}}
+     :witan/params {:start-year-avg-mort 2010, :end-year-avg-mort 2014, :last-proj-year 2018 :first-proj-year 2014}}
     {:witan/name :proj-intl-in-migrants
      :witan/version "1.0.0"
      :witan/type :function

--- a/test/witan/models/dem/ccm/core/projection_loop_test.clj
+++ b/test/witan/models/dem/ccm/core/projection_loop_test.clj
@@ -30,7 +30,7 @@
                    "./datasets/test_datasets/model_inputs/mort/death_improvement.csv"}))
 
 (def params {;; Core module
-             :first-proj-year 2014
+             :first-proj-year 2015
              :last-proj-year 2016
              ;; Fertility module
              :fert-base-year 2014

--- a/test/witan/models/run_models_test.clj
+++ b/test/witan/models/run_models_test.clj
@@ -70,18 +70,31 @@
                     {:end-population
                      "./datasets/test_datasets/r_outputs_for_testing/core/bristol_end_population_2015.csv"}))
 
+(def r-output-2040 (ld/load-datasets
+                    {:end-population
+                     "./datasets/test_datasets/r_outputs_for_testing/core/bristol_end_population_2040.csv"}))
+
 (deftest run-workspace-test
   (testing "The historical and projection data is returned"
     (let [proj-bristol-2015 (wds/select-from-ds (run-workspace datasets gss-bristol params-2015)
                                                 {:year 2015})
           r-proj-bristol-2015 (ds/rename-columns (:end-population r-output-2015)
                                                  {:popn :popn-r})
-          joined-ds (wds/join proj-bristol-2015 r-proj-bristol-2015 [:gss-code :sex :age :year])]
+          joined-ds-2015 (wds/join proj-bristol-2015 r-proj-bristol-2015 [:gss-code :sex :age :year])
+          proj-bristol-2040 (wds/select-from-ds (run-workspace datasets gss-bristol (assoc params-2015 :last-proj-year 2040))
+                                                {:year 2040})
+          r-proj-bristol-2040 (ds/rename-columns (:end-population r-output-2040)
+                                                 {:popn :popn-r})
+          joined-ds-2040 (wds/join proj-bristol-2040 r-proj-bristol-2040 [:gss-code :sex :age :year])]
       (is proj-bristol-2015)
       (is (= (:shape proj-bristol-2015) (:shape r-proj-bristol-2015)))
-      (is (every? #(fp-equals? (wds/subset-ds joined-ds :rows % :cols :popn)
-                               (wds/subset-ds joined-ds :rows % :cols :popn-r) 0.0000000001)
-                  (range (first (:shape joined-ds))))))))
+      (is (every? #(fp-equals? (wds/subset-ds joined-ds-2015 :rows % :cols :popn)
+                               (wds/subset-ds joined-ds-2015 :rows % :cols :popn-r) 0.0000000001)
+                  (range (first (:shape joined-ds-2015)))))
+      (is (= (:shape proj-bristol-2040) (:shape r-proj-bristol-2040)))
+      (is (every? #(fp-equals? (wds/subset-ds joined-ds-2040 :rows % :cols :popn)
+                               (wds/subset-ds joined-ds-2040 :rows % :cols :popn-r) 0.0000000001)
+                  (range (first (:shape joined-ds-2040))))))))
 
 (deftest get-district-test
   (testing "fn recovers correct district name"


### PR DESCRIPTION
Bug info: The further into the future the population projection for the ccm was the more likely it was that the values returned would be incorrect. Not only would the values further into the future be wrong but the earlier values (i.e. 2015) would also have changed.

This bug was eventually tracked down to a merge conflict in the workflow whereby we are currently unable to predict how two branches in the workflow are subsequently merged together. These branches have some of the same data in them, but on one branch this data has been updated. Previously there was not a predicate for the order in which these data were merged.

Subsequently when projecting further into the future, one of the branches (mortality/death prediction), which uses the parameter provided to define how far into the future to project, would take longer to run, merge second and provide the un-modified values in the population projection.

This bug has been fixed by a minor increasing the run time and reducing parallelisation, through modification to the workflow, so that the death projection is always run first.
