### PR TITLE
Historical data added to popn projection output

### DIFF
--- a/src/witan/models/dem/ccm/core/projection_loop.clj
+++ b/src/witan/models/dem/ccm/core/projection_loop.clj
@@ -40,7 +40,7 @@
                          :aggregated-births BirthsSchema
                          :aggregated-deaths DeathsOutputSchema}}
   [{:keys [historic-population]} {:keys [first-proj-year]}]
-  {:aggregated-population (wds/select-from-ds historic-population {:year (dec first-proj-year)})
+  {:aggregated-population (wds/select-from-ds historic-population {:year {:lt first-proj-year}})
    :aggregated-births (create-empty-ds BirthsSchema)
    :aggregated-deaths (create-empty-ds DeathsOutputSchema)
    :aggregated-net-migration (create-empty-ds NetMigrationSchema)})


### PR DESCRIPTION
The historical data and the projection data are sorted differently. The historical data is sorted by age and the projected data by year.

I have tested adding a sorting step, but it would mean:
1. Adding Incanter to the repo, which we are trying to steer clear of
2. Using incanter/$order is VERY slow, prohibitively so when compared to how long it actually takes to run the projection.

I've tested ordering the historical data (by year) as soon as it is uploaded and closer to the end of the process and neither make any difference in terms of processing time. For this reason I have left it out for the moment.
