### PR TITLE
Updated README to label demo tool as defunct

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ Turn it off with:
 ## Use `witan.models.demography`
 
 You can currently run a `witan.models.demography` cohort-component model on your terminal.
-To test/use it, follow the instructions below.
+To test/use it, follow the instructions below. 
+
+!!! Please note this feature is no longer being updated/maintained !!!
 
 ### Requirements
 


### PR DESCRIPTION
Minor change to README to alert users to the fact that the demo tool is not being updated in line with changes made to the master
